### PR TITLE
Remove unused admin routes import

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -5,7 +5,6 @@ import cookieParser from "cookie-parser";
 import path from "path";
 import fs from "fs";
 import { registerRoutes } from "./routes";
-import adminRoutes from "./routes/admin";
 import { setupVite, serveStatic, log } from "./vite";
 import { db } from "./db";
 import { createServer } from "http";


### PR DESCRIPTION
## Summary
- remove the unused `adminRoutes` import from the main server entry point to avoid unused import warnings

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c983fdc0488331b7d861ae33593d2d