### PR TITLE
Add Drizzle model types and DTO mappers for shared tables

### DIFF
--- a/scripts/generate-dtos.mjs
+++ b/scripts/generate-dtos.mjs
@@ -1,0 +1,370 @@
+#!/usr/bin/env node
+import fs from "fs";
+import path from "path";
+
+const repoRoot = path.resolve(process.cwd());
+const sharedDir = path.join(repoRoot, "shared");
+
+const targetArg = process.argv[2];
+const tableFiles = fs
+  .readdirSync(sharedDir)
+  .filter((file) => file.endsWith("Tables.ts"))
+  .filter((file) => (targetArg ? file === targetArg : true));
+
+const PRIORITY_FIELDS = [
+  "id",
+  "name",
+  "title",
+  "slug",
+  "status",
+  "state",
+  "type",
+  "category",
+  "key",
+  "code",
+  "identifier",
+  "modelId",
+  "ruleId",
+  "sessionId",
+  "neuronId",
+  "userId",
+  "offerId",
+  "destinationId",
+  "archetypeId",
+  "planId",
+  "journeyId",
+  "campaignId",
+  "vertical",
+  "region",
+  "country",
+  "market",
+  "language",
+  "locale",
+  "segment",
+  "audience",
+  "channel",
+  "priority",
+  "severity",
+  "level",
+  "stage",
+  "createdAt",
+  "updatedAt",
+  "description",
+  "summary",
+  "email",
+  "phone",
+  "version",
+  "provider",
+  "integrationId",
+  "teamId",
+  "role",
+  "goalId",
+  "toolId",
+  "widgetId",
+  "componentId",
+  "pipelineId",
+  "department",
+  "budget",
+  "amount",
+  "metric",
+  "eventType",
+  "workflowId",
+  "funnelId",
+  "offerType",
+  "productId",
+  "sku",
+  "appId",
+  "tenantId",
+  "groupId",
+  "tag",
+  "label",
+  "quizType",
+  "analyticsType",
+  "source",
+  "providerId",
+  "environment",
+  "levelName",
+  "module",
+  "service",
+  "queue",
+  "stack",
+  "bucket",
+  "topic",
+];
+
+const ALWAYS_INCLUDE = new Set(["id", "createdAt", "updatedAt"]);
+const MAX_FIELDS = 8;
+const MIN_FIELDS = 3;
+
+const toCamelCase = (value) => value.charAt(0).toLowerCase() + value.slice(1);
+
+const unique = (arr) => Array.from(new Set(arr));
+
+const splitIdentifier = (value) =>
+  value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/_/g, " ")
+    .split(" ")
+    .filter(Boolean);
+
+const singularizeWord = (word) => {
+  if (word.endsWith("ies")) {
+    return `${word.slice(0, -3)}y`;
+  }
+  if (word.endsWith("ses")) {
+    return word.slice(0, -2);
+  }
+  if (word.endsWith("s") && !word.endsWith("ss")) {
+    return word.slice(0, -1);
+  }
+  return word;
+};
+
+const toPascalCaseFromWords = (words) =>
+  words.map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join("");
+
+const createTypeName = (tableConst) => {
+  const words = splitIdentifier(tableConst);
+  if (!words.length) {
+    return toPascalCaseFromWords([tableConst]);
+  }
+  const lastIndex = words.length - 1;
+  words[lastIndex] = singularizeWord(words[lastIndex]);
+  return toPascalCaseFromWords(words);
+};
+
+const createFilePrefix = (fileName) => {
+  const base = fileName.replace(/Tables\.ts$/, "");
+  const words = splitIdentifier(base);
+  return toPascalCaseFromWords(words);
+};
+
+const extractColumns = (content, tableConst) => {
+  const marker = `export const ${tableConst} = pgTable`;
+  const startIndex = content.indexOf(marker);
+  if (startIndex === -1) {
+    console.warn(`Could not find columns for ${tableConst}`);
+    return [];
+  }
+  const lines = content.slice(startIndex).split("\n");
+  const columns = [];
+  for (let i = 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    if (trimmed.startsWith("});") || trimmed.startsWith("},") || trimmed.startsWith(")")) {
+      break;
+    }
+    const match = line.match(/^\s*(\w+):/);
+    if (match) {
+      columns.push(match[1]);
+    }
+  }
+  return columns;
+};
+
+const buildDtoKeys = (columns) => {
+  if (!columns.length) {
+    return [];
+  }
+  const columnSet = new Set(columns);
+  const prioritized = [];
+  for (const field of PRIORITY_FIELDS) {
+    if (columnSet.has(field)) {
+      prioritized.push(field);
+    }
+  }
+  const ordered = unique(prioritized);
+  if (!ordered.includes("id") && columnSet.has("id")) {
+    ordered.unshift("id");
+  }
+  if (!ordered.length) {
+    ordered.push(columns[0]);
+  }
+  while (ordered.length < MIN_FIELDS && ordered.length < columns.length) {
+    const next = columns.find((column) => !ordered.includes(column));
+    if (!next) {
+      break;
+    }
+    ordered.push(next);
+  }
+  let limited = ordered.slice(0, MAX_FIELDS);
+  for (const field of ALWAYS_INCLUDE) {
+    if (columnSet.has(field) && !limited.includes(field)) {
+      limited.push(field);
+    }
+  }
+  limited = unique(limited);
+  return limited;
+};
+
+const ensureDrizzleImport = (content, needsInsert) => {
+  const regex = /import \{([^}]+)\} from "drizzle-orm";/;
+  if (regex.test(content)) {
+    return content.replace(regex, (_, specifiers) => {
+      const parts = specifiers
+        .split(",")
+        .map((part) => part.trim())
+        .filter(Boolean);
+      const set = new Set(parts);
+      set.add("InferSelectModel");
+      if (needsInsert) {
+        set.add("InferInsertModel");
+      }
+      const ordered = Array.from(set).sort((a, b) => a.localeCompare(b));
+      return `import { ${ordered.join(", ")} } from "drizzle-orm";`;
+    });
+  }
+  const importLine = `import { ${needsInsert ? "InferInsertModel, " : ""}InferSelectModel } from "drizzle-orm";`;
+  const lines = content.split("\n");
+  let insertIndex = 0;
+  for (let i = 0; i < lines.length; i += 1) {
+    if (lines[i].startsWith("import ")) {
+      insertIndex = i + 1;
+      continue;
+    }
+    if (lines[i].trim() === "") {
+      insertIndex = i + 1;
+      continue;
+    }
+    break;
+  }
+  lines.splice(insertIndex, 0, importLine);
+  return lines.join("\n");
+};
+
+const ensureDtoHelperImport = (content) => {
+  if (content.includes("pickDTOFields")) {
+    return content;
+  }
+  const lines = content.split("\n");
+  let lastImportIndex = -1;
+  for (let i = 0; i < lines.length; i += 1) {
+    if (lines[i].startsWith("import ")) {
+      lastImportIndex = i;
+    } else if (lines[i].trim() === "") {
+      continue;
+    } else {
+      break;
+    }
+  }
+  lines.splice(lastImportIndex + 1, 0, 'import { pickDTOFields } from "./dtoHelpers";');
+  return lines.join("\n");
+};
+
+const processFile = (fileName) => {
+  const filePath = path.join(sharedDir, fileName);
+  const original = fs.readFileSync(filePath, "utf8");
+  let content = original;
+
+  const selectInfo = new Map();
+
+  const selectMatches = content.matchAll(
+    /export type (\w+) = (?:InferSelectModel<typeof (\w+)>|typeof (\w+)\.\$inferSelect);/g,
+  );
+  for (const match of selectMatches) {
+    const [, typeName, newStyleTable, legacyTable] = match;
+    const tableConst = newStyleTable ?? legacyTable;
+    if (tableConst) {
+      selectInfo.set(typeName, tableConst);
+    }
+  }
+
+  content = content.replace(/export type (\w+) = typeof (\w+)\.\$inferSelect;/g, (_, typeName, tableConst) => {
+    selectInfo.set(typeName, tableConst);
+    return `export type ${typeName} = InferSelectModel<typeof ${tableConst}>;`;
+  });
+
+  const insertTables = new Set();
+
+  const insertMatches = content.matchAll(
+    /export type (\w+) = (?:InferInsertModel<typeof (\w+)>|typeof (\w+)\.\$inferInsert);/g,
+  );
+  for (const match of insertMatches) {
+    const [, , newStyleTable, legacyTable] = match;
+    const tableConst = newStyleTable ?? legacyTable;
+    if (tableConst) {
+      insertTables.add(tableConst);
+    }
+  }
+
+  content = content.replace(/export type (\w+) = typeof (\w+)\.\$inferInsert;/g, (_, typeName, tableConst) => {
+    insertTables.add(tableConst);
+    return `export type ${typeName} = InferInsertModel<typeof ${tableConst}>;`;
+  });
+
+  content = content.replace(/export type Insert(\w+) = z\.infer<[^>]+>;/g, (match, typeName) => {
+    const tableConst = selectInfo.get(typeName);
+    if (!tableConst) {
+      console.warn(`Skipping insert replacement for ${typeName} in ${fileName}`);
+      return match;
+    }
+    insertTables.add(tableConst);
+    return `export type Insert${typeName} = InferInsertModel<typeof ${tableConst}>;`;
+  });
+
+  const tableMatches = [...content.matchAll(/export const (\w+) = pgTable/g)];
+  const tableNames = tableMatches.map(([, name]) => name);
+  const existingTables = new Set(selectInfo.values());
+  const newTypeDefs = [];
+  const filePrefix = createFilePrefix(fileName);
+
+  for (const tableConst of tableNames) {
+    if (existingTables.has(tableConst)) {
+      continue;
+    }
+    const baseTypeName = createTypeName(tableConst);
+    let typeName = filePrefix ? `${filePrefix}${baseTypeName}` : baseTypeName;
+    while (selectInfo.has(typeName)) {
+      typeName = `${typeName}Model`;
+    }
+    selectInfo.set(typeName, tableConst);
+    insertTables.add(tableConst);
+    existingTables.add(tableConst);
+    newTypeDefs.push(
+      `export type ${typeName} = InferSelectModel<typeof ${tableConst}>;`,
+      `export type Insert${typeName} = InferInsertModel<typeof ${tableConst}>;`,
+    );
+  }
+
+  content = ensureDrizzleImport(content, insertTables.size > 0);
+  content = ensureDtoHelperImport(content);
+
+  const dtoBlocks = [];
+
+  for (const [typeName, tableConst] of selectInfo.entries()) {
+    const columns = extractColumns(original, tableConst);
+    const dtoKeys = buildDtoKeys(columns);
+    if (!dtoKeys.length) {
+      continue;
+    }
+    const camel = toCamelCase(typeName);
+    const arrayName = `${camel}DTOKeys`;
+    const keyList = dtoKeys.map((key) => `"${key}"`).join(", ");
+    const interfaceName = `${typeName}DTO`;
+    const functionName = `to${typeName}DTO`;
+    const block = `const ${arrayName} = [${keyList}] as const;
+
+export interface ${interfaceName}
+  extends Pick<${typeName}, (typeof ${arrayName})[number]> {}
+
+export const ${functionName} = (${camel}: ${typeName}): ${interfaceName} =>
+  pickDTOFields(${camel}, ${arrayName});`;
+    dtoBlocks.push(block);
+  }
+
+  const typeExportInsert = newTypeDefs.length ? `${newTypeDefs.join("\n")}\n\n` : "";
+  const dtoSection = `${typeExportInsert}// DTOs\n${dtoBlocks.join("\n\n\n")}\n`;
+
+  content = content.replace(/\s*$/, "");
+  if (content.includes("// DTOs")) {
+    content = content.replace(/\/\/ DTOs[\s\S]*$/, dtoSection);
+  } else {
+    content = `${content}\n\n${dtoSection}`;
+  }
+
+  fs.writeFileSync(filePath, `${content}\n`);
+};
+
+for (const file of tableFiles) {
+  processFile(file);
+}

--- a/shared/aiMLTables.ts
+++ b/shared/aiMLTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, dec
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // AI/ML Model Registry - Track all ML models and their performance
 export const aiMLModels = pgTable("ai_ml_models", {
   id: serial("id").primaryKey(),
@@ -280,32 +282,123 @@ export const insertAiMLAuditTrailSchema = createInsertSchema(aiMLAuditTrail).omi
 });
 
 // Types
-export type InsertAiMLModel = z.infer<typeof insertAiMLModelSchema>;
-export type AiMLModel = typeof aiMLModels.$inferSelect;
+export type InsertAiMLModel = InferInsertModel<typeof aiMLModels>;
+export type AiMLModel = InferSelectModel<typeof aiMLModels>;
 
-export type InsertLearningCycle = z.infer<typeof insertLearningCycleSchema>;
-export type LearningCycle = typeof learningCycles.$inferSelect;
+export type InsertLearningCycle = InferInsertModel<typeof learningCycles>;
+export type LearningCycle = InferSelectModel<typeof learningCycles>;
 
-export type InsertPersonalizationRule = z.infer<typeof insertPersonalizationRuleSchema>;
-export type PersonalizationRule = typeof personalizationRules.$inferSelect;
+export type InsertPersonalizationRule = InferInsertModel<typeof personalizationRules>;
+export type PersonalizationRule = InferSelectModel<typeof personalizationRules>;
 
-export type InsertNeuronDataPipeline = z.infer<typeof insertNeuronDataPipelineSchema>;
-export type NeuronDataPipeline = typeof neuronDataPipelines.$inferSelect;
+export type InsertNeuronDataPipeline = InferInsertModel<typeof neuronDataPipelines>;
+export type NeuronDataPipeline = InferSelectModel<typeof neuronDataPipelines>;
 
-export type InsertAiMLExperiment = z.infer<typeof insertAiMLExperimentSchema>;
-export type AiMLExperiment = typeof aiMLExperiments.$inferSelect;
+export type InsertAiMLExperiment = InferInsertModel<typeof aiMLExperiments>;
+export type AiMLExperiment = InferSelectModel<typeof aiMLExperiments>;
 
-export type InsertContentOptimizationLog = z.infer<typeof insertContentOptimizationLogSchema>;
-export type ContentOptimizationLog = typeof contentOptimizationLogs.$inferSelect;
+export type InsertContentOptimizationLog = InferInsertModel<typeof contentOptimizationLogs>;
+export type ContentOptimizationLog = InferSelectModel<typeof contentOptimizationLogs>;
 
-export type InsertAiMLAnalytics = z.infer<typeof insertAiMLAnalyticsSchema>;
-export type AiMLAnalytics = typeof aiMLAnalytics.$inferSelect;
+export type InsertAiMLAnalytics = InferInsertModel<typeof aiMLAnalytics>;
+export type AiMLAnalytics = InferSelectModel<typeof aiMLAnalytics>;
 
-export type InsertModelTrainingJob = z.infer<typeof insertModelTrainingJobSchema>;
-export type ModelTrainingJob = typeof modelTrainingJobs.$inferSelect;
+export type InsertModelTrainingJob = InferInsertModel<typeof modelTrainingJobs>;
+export type ModelTrainingJob = InferSelectModel<typeof modelTrainingJobs>;
 
-export type InsertEmpireBrainConfig = z.infer<typeof insertEmpireBrainConfigSchema>;
-export type EmpireBrainConfig = typeof empireBrainConfig.$inferSelect;
+export type InsertEmpireBrainConfig = InferInsertModel<typeof empireBrainConfig>;
+export type EmpireBrainConfig = InferSelectModel<typeof empireBrainConfig>;
 
-export type InsertAiMLAuditTrail = z.infer<typeof insertAiMLAuditTrailSchema>;
-export type AiMLAuditTrail = typeof aiMLAuditTrail.$inferSelect;
+export type InsertAiMLAuditTrail = InferInsertModel<typeof aiMLAuditTrail>;
+export type AiMLAuditTrail = InferSelectModel<typeof aiMLAuditTrail>;
+
+// DTOs
+const aiMLModelDTOKeys = ["id", "name", "modelId", "createdAt", "updatedAt", "description", "version"] as const;
+
+export interface AiMLModelDTO
+  extends Pick<AiMLModel, (typeof aiMLModelDTOKeys)[number]> {}
+
+export const toAiMLModelDTO = (aiMLModel: AiMLModel): AiMLModelDTO =>
+  pickDTOFields(aiMLModel, aiMLModelDTOKeys);
+
+
+const learningCycleDTOKeys = ["id", "status", "type", "createdAt"] as const;
+
+export interface LearningCycleDTO
+  extends Pick<LearningCycle, (typeof learningCycleDTOKeys)[number]> {}
+
+export const toLearningCycleDTO = (learningCycle: LearningCycle): LearningCycleDTO =>
+  pickDTOFields(learningCycle, learningCycleDTOKeys);
+
+
+const personalizationRuleDTOKeys = ["id", "name", "ruleId", "vertical", "priority", "createdAt", "updatedAt", "description"] as const;
+
+export interface PersonalizationRuleDTO
+  extends Pick<PersonalizationRule, (typeof personalizationRuleDTOKeys)[number]> {}
+
+export const toPersonalizationRuleDTO = (personalizationRule: PersonalizationRule): PersonalizationRuleDTO =>
+  pickDTOFields(personalizationRule, personalizationRuleDTOKeys);
+
+
+const neuronDataPipelineDTOKeys = ["id", "type", "neuronId", "vertical", "createdAt", "updatedAt"] as const;
+
+export interface NeuronDataPipelineDTO
+  extends Pick<NeuronDataPipeline, (typeof neuronDataPipelineDTOKeys)[number]> {}
+
+export const toNeuronDataPipelineDTO = (neuronDataPipeline: NeuronDataPipeline): NeuronDataPipelineDTO =>
+  pickDTOFields(neuronDataPipeline, neuronDataPipelineDTOKeys);
+
+
+const aiMLExperimentDTOKeys = ["id", "name", "status", "type", "modelId", "vertical", "createdAt", "updatedAt"] as const;
+
+export interface AiMLExperimentDTO
+  extends Pick<AiMLExperiment, (typeof aiMLExperimentDTOKeys)[number]> {}
+
+export const toAiMLExperimentDTO = (aiMLExperiment: AiMLExperiment): AiMLExperimentDTO =>
+  pickDTOFields(aiMLExperiment, aiMLExperimentDTOKeys);
+
+
+const contentOptimizationLogDTOKeys = ["id", "vertical", "createdAt"] as const;
+
+export interface ContentOptimizationLogDTO
+  extends Pick<ContentOptimizationLog, (typeof contentOptimizationLogDTOKeys)[number]> {}
+
+export const toContentOptimizationLogDTO = (contentOptimizationLog: ContentOptimizationLog): ContentOptimizationLogDTO =>
+  pickDTOFields(contentOptimizationLog, contentOptimizationLogDTOKeys);
+
+
+const aiMLAnalyticsDTOKeys = ["id", "neuronId", "vertical", "createdAt"] as const;
+
+export interface AiMLAnalyticsDTO
+  extends Pick<AiMLAnalytics, (typeof aiMLAnalyticsDTOKeys)[number]> {}
+
+export const toAiMLAnalyticsDTO = (aiMLAnalytics: AiMLAnalytics): AiMLAnalyticsDTO =>
+  pickDTOFields(aiMLAnalytics, aiMLAnalyticsDTOKeys);
+
+
+const modelTrainingJobDTOKeys = ["id", "status", "modelId", "createdAt", "updatedAt"] as const;
+
+export interface ModelTrainingJobDTO
+  extends Pick<ModelTrainingJob, (typeof modelTrainingJobDTOKeys)[number]> {}
+
+export const toModelTrainingJobDTO = (modelTrainingJob: ModelTrainingJob): ModelTrainingJobDTO =>
+  pickDTOFields(modelTrainingJob, modelTrainingJobDTOKeys);
+
+
+const empireBrainConfigDTOKeys = ["id", "category", "createdAt", "updatedAt", "description", "version"] as const;
+
+export interface EmpireBrainConfigDTO
+  extends Pick<EmpireBrainConfig, (typeof empireBrainConfigDTOKeys)[number]> {}
+
+export const toEmpireBrainConfigDTO = (empireBrainConfig: EmpireBrainConfig): EmpireBrainConfigDTO =>
+  pickDTOFields(empireBrainConfig, empireBrainConfigDTOKeys);
+
+
+const aiMLAuditTrailDTOKeys = ["id", "sessionId", "userId"] as const;
+
+export interface AiMLAuditTrailDTO
+  extends Pick<AiMLAuditTrail, (typeof aiMLAuditTrailDTOKeys)[number]> {}
+
+export const toAiMLAuditTrailDTO = (aiMLAuditTrail: AiMLAuditTrail): AiMLAuditTrailDTO =>
+  pickDTOFields(aiMLAuditTrail, aiMLAuditTrailDTOKeys);
+

--- a/shared/aiNativeTables.ts
+++ b/shared/aiNativeTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // ==========================================
 // AI-NATIVE OPERATING SYSTEM TABLES
 // ==========================================
@@ -206,24 +208,24 @@ export const federationTasks = pgTable("federation_tasks", {
 });
 
 // Type definitions for better TypeScript support
-export type LlmAgent = typeof llmAgents.$inferSelect;
-export type NewLlmAgent = typeof llmAgents.$inferInsert;
-export type TaskRoutingHistory = typeof taskRoutingHistory.$inferSelect;
-export type NewTaskRoutingHistory = typeof taskRoutingHistory.$inferInsert;
-export type AgentMemory = typeof agentMemories.$inferSelect;
-export type NewAgentMemory = typeof agentMemories.$inferInsert;
-export type PromptTemplate = typeof promptTemplates.$inferSelect;
-export type NewPromptTemplate = typeof promptTemplates.$inferInsert;
-export type AgenticWorkflow = typeof agenticWorkflows.$inferSelect;
-export type NewAgenticWorkflow = typeof agenticWorkflows.$inferInsert;
-export type WorkflowExecution = typeof workflowExecutions.$inferSelect;
-export type NewWorkflowExecution = typeof workflowExecutions.$inferInsert;
-export type RouterLearning = typeof routerLearning.$inferSelect;
-export type NewRouterLearning = typeof routerLearning.$inferInsert;
-export type AgentUsageTracking = typeof agentUsageTracking.$inferSelect;
-export type NewAgentUsageTracking = typeof agentUsageTracking.$inferInsert;
-export type FederationTask = typeof federationTasks.$inferSelect;
-export type NewFederationTask = typeof federationTasks.$inferInsert;
+export type LlmAgent = InferSelectModel<typeof llmAgents>;
+export type NewLlmAgent = InferInsertModel<typeof llmAgents>;
+export type TaskRoutingHistory = InferSelectModel<typeof taskRoutingHistory>;
+export type NewTaskRoutingHistory = InferInsertModel<typeof taskRoutingHistory>;
+export type AgentMemory = InferSelectModel<typeof agentMemories>;
+export type NewAgentMemory = InferInsertModel<typeof agentMemories>;
+export type PromptTemplate = InferSelectModel<typeof promptTemplates>;
+export type NewPromptTemplate = InferInsertModel<typeof promptTemplates>;
+export type AgenticWorkflow = InferSelectModel<typeof agenticWorkflows>;
+export type NewAgenticWorkflow = InferInsertModel<typeof agenticWorkflows>;
+export type WorkflowExecution = InferSelectModel<typeof workflowExecutions>;
+export type NewWorkflowExecution = InferInsertModel<typeof workflowExecutions>;
+export type RouterLearning = InferSelectModel<typeof routerLearning>;
+export type NewRouterLearning = InferInsertModel<typeof routerLearning>;
+export type AgentUsageTracking = InferSelectModel<typeof agentUsageTracking>;
+export type NewAgentUsageTracking = InferInsertModel<typeof agentUsageTracking>;
+export type FederationTask = InferSelectModel<typeof federationTasks>;
+export type NewFederationTask = InferInsertModel<typeof federationTasks>;
 
 // Schema validations
 export const llmAgentSchema = createInsertSchema(llmAgents);
@@ -235,3 +237,85 @@ export const workflowExecutionSchema = createInsertSchema(workflowExecutions);
 export const routerLearningSchema = createInsertSchema(routerLearning);
 export const agentUsageTrackingSchema = createInsertSchema(agentUsageTracking);
 export const federationTaskSchema = createInsertSchema(federationTasks);
+
+// DTOs
+const llmAgentDTOKeys = ["id", "name", "status", "createdAt", "updatedAt", "provider"] as const;
+
+export interface LlmAgentDTO
+  extends Pick<LlmAgent, (typeof llmAgentDTOKeys)[number]> {}
+
+export const toLlmAgentDTO = (llmAgent: LlmAgent): LlmAgentDTO =>
+  pickDTOFields(llmAgent, llmAgentDTOKeys);
+
+
+const taskRoutingHistoryDTOKeys = ["id", "taskId", "taskType"] as const;
+
+export interface TaskRoutingHistoryDTO
+  extends Pick<TaskRoutingHistory, (typeof taskRoutingHistoryDTOKeys)[number]> {}
+
+export const toTaskRoutingHistoryDTO = (taskRoutingHistory: TaskRoutingHistory): TaskRoutingHistoryDTO =>
+  pickDTOFields(taskRoutingHistory, taskRoutingHistoryDTOKeys);
+
+
+const agentMemoryDTOKeys = ["id", "createdAt", "memoryId"] as const;
+
+export interface AgentMemoryDTO
+  extends Pick<AgentMemory, (typeof agentMemoryDTOKeys)[number]> {}
+
+export const toAgentMemoryDTO = (agentMemory: AgentMemory): AgentMemoryDTO =>
+  pickDTOFields(agentMemory, agentMemoryDTOKeys);
+
+
+const promptTemplateDTOKeys = ["id", "name", "status", "category", "createdAt", "updatedAt", "description", "version"] as const;
+
+export interface PromptTemplateDTO
+  extends Pick<PromptTemplate, (typeof promptTemplateDTOKeys)[number]> {}
+
+export const toPromptTemplateDTO = (promptTemplate: PromptTemplate): PromptTemplateDTO =>
+  pickDTOFields(promptTemplate, promptTemplateDTOKeys);
+
+
+const agenticWorkflowDTOKeys = ["id", "name", "status", "category", "createdAt", "updatedAt", "description", "version"] as const;
+
+export interface AgenticWorkflowDTO
+  extends Pick<AgenticWorkflow, (typeof agenticWorkflowDTOKeys)[number]> {}
+
+export const toAgenticWorkflowDTO = (agenticWorkflow: AgenticWorkflow): AgenticWorkflowDTO =>
+  pickDTOFields(agenticWorkflow, agenticWorkflowDTOKeys);
+
+
+const workflowExecutionDTOKeys = ["id", "status", "userId", "workflowId"] as const;
+
+export interface WorkflowExecutionDTO
+  extends Pick<WorkflowExecution, (typeof workflowExecutionDTOKeys)[number]> {}
+
+export const toWorkflowExecutionDTO = (workflowExecution: WorkflowExecution): WorkflowExecutionDTO =>
+  pickDTOFields(workflowExecution, workflowExecutionDTOKeys);
+
+
+const routerLearningDTOKeys = ["id", "learningId", "taskType"] as const;
+
+export interface RouterLearningDTO
+  extends Pick<RouterLearning, (typeof routerLearningDTOKeys)[number]> {}
+
+export const toRouterLearningDTO = (routerLearning: RouterLearning): RouterLearningDTO =>
+  pickDTOFields(routerLearning, routerLearningDTOKeys);
+
+
+const agentUsageTrackingDTOKeys = ["id", "userId", "trackingId"] as const;
+
+export interface AgentUsageTrackingDTO
+  extends Pick<AgentUsageTracking, (typeof agentUsageTrackingDTOKeys)[number]> {}
+
+export const toAgentUsageTrackingDTO = (agentUsageTracking: AgentUsageTracking): AgentUsageTrackingDTO =>
+  pickDTOFields(agentUsageTracking, agentUsageTrackingDTOKeys);
+
+
+const federationTaskDTOKeys = ["id", "status", "priority", "createdAt"] as const;
+
+export interface FederationTaskDTO
+  extends Pick<FederationTask, (typeof federationTaskDTOKeys)[number]> {}
+
+export const toFederationTaskDTO = (federationTask: FederationTask): FederationTaskDTO =>
+  pickDTOFields(federationTask, federationTaskDTOKeys);
+

--- a/shared/aiToolsTables.ts
+++ b/shared/aiToolsTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, integer, decimal, boolean, timestamp, jsonb, uuid } from
 import { createInsertSchema } from 'drizzle-zod';
 import { z } from 'zod';
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // AI Tools Core Tables
 export const aiToolsArchetypes = pgTable('ai_tools_archetypes', {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
@@ -432,20 +434,142 @@ export const insertAiToolsLeadSchema = createInsertSchema(aiToolsLeads, {
 });
 
 // Type exports
-export type AiToolsArchetype = typeof aiToolsArchetypes.$inferSelect;
-export type InsertAiToolsArchetype = z.infer<typeof insertAiToolsArchetypeSchema>;
+export type AiToolsArchetype = InferSelectModel<typeof aiToolsArchetypes>;
+export type InsertAiToolsArchetype = InferInsertModel<typeof aiToolsArchetypes>;
 
-export type AiTool = typeof aiTools.$inferSelect;
-export type InsertAiTool = z.infer<typeof insertAiToolSchema>;
+export type AiTool = InferSelectModel<typeof aiTools>;
+export type InsertAiTool = InferInsertModel<typeof aiTools>;
 
-export type AiToolsOffer = typeof aiToolsOffers.$inferSelect;
-export type InsertAiToolsOffer = z.infer<typeof insertAiToolsOfferSchema>;
+export type AiToolsOffer = InferSelectModel<typeof aiToolsOffers>;
+export type InsertAiToolsOffer = InferInsertModel<typeof aiToolsOffers>;
 
-export type AiToolsQuiz = typeof aiToolsQuizzes.$inferSelect;
-export type InsertAiToolsQuiz = z.infer<typeof insertAiToolsQuizSchema>;
+export type AiToolsQuiz = InferSelectModel<typeof aiToolsQuizzes>;
+export type InsertAiToolsQuiz = InferInsertModel<typeof aiToolsQuizzes>;
 
-export type AiToolsContent = typeof aiToolsContent.$inferSelect;
-export type InsertAiToolsContent = z.infer<typeof insertAiToolsContentSchema>;
+export type AiToolsContent = InferSelectModel<typeof aiToolsContent>;
+export type InsertAiToolsContent = InferInsertModel<typeof aiToolsContent>;
 
-export type AiToolsLead = typeof aiToolsLeads.$inferSelect;
-export type InsertAiToolsLead = z.infer<typeof insertAiToolsLeadSchema>;
+export type AiToolsLead = InferSelectModel<typeof aiToolsLeads>;
+export type InsertAiToolsLead = InferInsertModel<typeof aiToolsLeads>;
+
+export type AiToolsCategory = InferSelectModel<typeof aiToolsCategories>;
+export type InsertAiToolsCategory = InferInsertModel<typeof aiToolsCategories>;
+export type AiToolsReview = InferSelectModel<typeof aiToolsReviews>;
+export type InsertAiToolsReview = InferInsertModel<typeof aiToolsReviews>;
+export type AiToolsComparison = InferSelectModel<typeof aiToolsComparisons>;
+export type InsertAiToolsComparison = InferInsertModel<typeof aiToolsComparisons>;
+export type AiToolsQuizResult = InferSelectModel<typeof aiToolsQuizResults>;
+export type InsertAiToolsQuizResult = InferInsertModel<typeof aiToolsQuizResults>;
+export type AiToolsExperiment = InferSelectModel<typeof aiToolsExperiments>;
+export type InsertAiToolsExperiment = InferInsertModel<typeof aiToolsExperiments>;
+export type AiToolsAnalytic = InferSelectModel<typeof aiToolsAnalytics>;
+export type InsertAiToolsAnalytic = InferInsertModel<typeof aiToolsAnalytics>;
+
+// DTOs
+const aiToolsArchetypeDTOKeys = ["id", "name", "slug", "createdAt", "updatedAt", "description"] as const;
+
+export interface AiToolsArchetypeDTO
+  extends Pick<AiToolsArchetype, (typeof aiToolsArchetypeDTOKeys)[number]> {}
+
+export const toAiToolsArchetypeDTO = (aiToolsArchetype: AiToolsArchetype): AiToolsArchetypeDTO =>
+  pickDTOFields(aiToolsArchetype, aiToolsArchetypeDTOKeys);
+
+
+const aiToolDTOKeys = ["id", "name", "slug", "type", "createdAt", "updatedAt", "description"] as const;
+
+export interface AiToolDTO
+  extends Pick<AiTool, (typeof aiToolDTOKeys)[number]> {}
+
+export const toAiToolDTO = (aiTool: AiTool): AiToolDTO =>
+  pickDTOFields(aiTool, aiToolDTOKeys);
+
+
+const aiToolsOfferDTOKeys = ["id", "title", "createdAt", "updatedAt", "description", "toolId", "offerType"] as const;
+
+export interface AiToolsOfferDTO
+  extends Pick<AiToolsOffer, (typeof aiToolsOfferDTOKeys)[number]> {}
+
+export const toAiToolsOfferDTO = (aiToolsOffer: AiToolsOffer): AiToolsOfferDTO =>
+  pickDTOFields(aiToolsOffer, aiToolsOfferDTOKeys);
+
+
+const aiToolsQuizDTOKeys = ["id", "title", "type", "createdAt", "updatedAt", "description"] as const;
+
+export interface AiToolsQuizDTO
+  extends Pick<AiToolsQuiz, (typeof aiToolsQuizDTOKeys)[number]> {}
+
+export const toAiToolsQuizDTO = (aiToolsQuiz: AiToolsQuiz): AiToolsQuizDTO =>
+  pickDTOFields(aiToolsQuiz, aiToolsQuizDTOKeys);
+
+
+const aiToolsContentDTOKeys = ["id", "title", "slug", "status", "type", "createdAt", "updatedAt"] as const;
+
+export interface AiToolsContentDTO
+  extends Pick<AiToolsContent, (typeof aiToolsContentDTOKeys)[number]> {}
+
+export const toAiToolsContentDTO = (aiToolsContent: AiToolsContent): AiToolsContentDTO =>
+  pickDTOFields(aiToolsContent, aiToolsContentDTOKeys);
+
+
+const aiToolsLeadDTOKeys = ["id", "sessionId", "createdAt", "updatedAt", "email", "source"] as const;
+
+export interface AiToolsLeadDTO
+  extends Pick<AiToolsLead, (typeof aiToolsLeadDTOKeys)[number]> {}
+
+export const toAiToolsLeadDTO = (aiToolsLead: AiToolsLead): AiToolsLeadDTO =>
+  pickDTOFields(aiToolsLead, aiToolsLeadDTOKeys);
+
+
+const aiToolsCategoryDTOKeys = ["id", "name", "slug", "createdAt", "description"] as const;
+
+export interface AiToolsCategoryDTO
+  extends Pick<AiToolsCategory, (typeof aiToolsCategoryDTOKeys)[number]> {}
+
+export const toAiToolsCategoryDTO = (aiToolsCategory: AiToolsCategory): AiToolsCategoryDTO =>
+  pickDTOFields(aiToolsCategory, aiToolsCategoryDTOKeys);
+
+
+const aiToolsReviewDTOKeys = ["id", "title", "sessionId", "userId", "createdAt", "updatedAt", "toolId"] as const;
+
+export interface AiToolsReviewDTO
+  extends Pick<AiToolsReview, (typeof aiToolsReviewDTOKeys)[number]> {}
+
+export const toAiToolsReviewDTO = (aiToolsReview: AiToolsReview): AiToolsReviewDTO =>
+  pickDTOFields(aiToolsReview, aiToolsReviewDTOKeys);
+
+
+const aiToolsComparisonDTOKeys = ["id", "name", "title", "slug", "createdAt", "updatedAt", "description"] as const;
+
+export interface AiToolsComparisonDTO
+  extends Pick<AiToolsComparison, (typeof aiToolsComparisonDTOKeys)[number]> {}
+
+export const toAiToolsComparisonDTO = (aiToolsComparison: AiToolsComparison): AiToolsComparisonDTO =>
+  pickDTOFields(aiToolsComparison, aiToolsComparisonDTOKeys);
+
+
+const aiToolsQuizResultDTOKeys = ["id", "sessionId", "userId"] as const;
+
+export interface AiToolsQuizResultDTO
+  extends Pick<AiToolsQuizResult, (typeof aiToolsQuizResultDTOKeys)[number]> {}
+
+export const toAiToolsQuizResultDTO = (aiToolsQuizResult: AiToolsQuizResult): AiToolsQuizResultDTO =>
+  pickDTOFields(aiToolsQuizResult, aiToolsQuizResultDTOKeys);
+
+
+const aiToolsExperimentDTOKeys = ["id", "name", "status", "type", "createdAt", "updatedAt", "description"] as const;
+
+export interface AiToolsExperimentDTO
+  extends Pick<AiToolsExperiment, (typeof aiToolsExperimentDTOKeys)[number]> {}
+
+export const toAiToolsExperimentDTO = (aiToolsExperiment: AiToolsExperiment): AiToolsExperimentDTO =>
+  pickDTOFields(aiToolsExperiment, aiToolsExperimentDTOKeys);
+
+
+const aiToolsAnalyticDTOKeys = ["id", "sessionId", "offerId", "toolId", "source"] as const;
+
+export interface AiToolsAnalyticDTO
+  extends Pick<AiToolsAnalytic, (typeof aiToolsAnalyticDTOKeys)[number]> {}
+
+export const toAiToolsAnalyticDTO = (aiToolsAnalytic: AiToolsAnalytic): AiToolsAnalyticDTO =>
+  pickDTOFields(aiToolsAnalytic, aiToolsAnalyticDTOKeys);
+

--- a/shared/apiDiffTables.ts
+++ b/shared/apiDiffTables.ts
@@ -1,3 +1,5 @@
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 /**
  * Live API Diff Tracker - Database Schema
  * Empire-Grade, Migration-Proof, Billion-Dollar Standards
@@ -428,23 +430,114 @@ export const insertApiAnalyticsSummarySchema = createInsertSchema(apiAnalyticsSu
 // TYPE EXPORTS
 // ================================
 
-export type ApiSchemaSnapshot = typeof apiSchemaSnapshots.$inferSelect;
-export type NewApiSchemaSnapshot = typeof apiSchemaSnapshots.$inferInsert;
-export type ApiEndpoint = typeof apiEndpoints.$inferSelect;
-export type NewApiEndpoint = typeof apiEndpoints.$inferInsert;
-export type ApiDiff = typeof apiDiffs.$inferSelect;
-export type NewApiDiff = typeof apiDiffs.$inferInsert;
-export type ApiChangeEvent = typeof apiChangeEvents.$inferSelect;
-export type NewApiChangeEvent = typeof apiChangeEvents.$inferInsert;
-export type ApiMonitoringRule = typeof apiMonitoringRules.$inferSelect;
-export type NewApiMonitoringRule = typeof apiMonitoringRules.$inferInsert;
-export type ApiAlertHistory = typeof apiAlertHistory.$inferSelect;
-export type NewApiAlertHistory = typeof apiAlertHistory.$inferInsert;
-export type ApiVersionHistory = typeof apiVersionHistory.$inferSelect;
-export type NewApiVersionHistory = typeof apiVersionHistory.$inferInsert;
-export type ApiRollbackOperation = typeof apiRollbackOperations.$inferSelect;
-export type NewApiRollbackOperation = typeof apiRollbackOperations.$inferInsert;
-export type ApiExportOperation = typeof apiExportOperations.$inferSelect;
-export type NewApiExportOperation = typeof apiExportOperations.$inferInsert;
-export type ApiAnalyticsSummary = typeof apiAnalyticsSummary.$inferSelect;
-export type NewApiAnalyticsSummary = typeof apiAnalyticsSummary.$inferInsert;
+export type ApiSchemaSnapshot = InferSelectModel<typeof apiSchemaSnapshots>;
+export type NewApiSchemaSnapshot = InferInsertModel<typeof apiSchemaSnapshots>;
+export type ApiEndpoint = InferSelectModel<typeof apiEndpoints>;
+export type NewApiEndpoint = InferInsertModel<typeof apiEndpoints>;
+export type ApiDiff = InferSelectModel<typeof apiDiffs>;
+export type NewApiDiff = InferInsertModel<typeof apiDiffs>;
+export type ApiChangeEvent = InferSelectModel<typeof apiChangeEvents>;
+export type NewApiChangeEvent = InferInsertModel<typeof apiChangeEvents>;
+export type ApiMonitoringRule = InferSelectModel<typeof apiMonitoringRules>;
+export type NewApiMonitoringRule = InferInsertModel<typeof apiMonitoringRules>;
+export type ApiAlertHistory = InferSelectModel<typeof apiAlertHistory>;
+export type NewApiAlertHistory = InferInsertModel<typeof apiAlertHistory>;
+export type ApiVersionHistory = InferSelectModel<typeof apiVersionHistory>;
+export type NewApiVersionHistory = InferInsertModel<typeof apiVersionHistory>;
+export type ApiRollbackOperation = InferSelectModel<typeof apiRollbackOperations>;
+export type NewApiRollbackOperation = InferInsertModel<typeof apiRollbackOperations>;
+export type ApiExportOperation = InferSelectModel<typeof apiExportOperations>;
+export type NewApiExportOperation = InferInsertModel<typeof apiExportOperations>;
+export type ApiAnalyticsSummary = InferSelectModel<typeof apiAnalyticsSummary>;
+export type NewApiAnalyticsSummary = InferInsertModel<typeof apiAnalyticsSummary>;
+
+// DTOs
+const apiSchemaSnapshotDTOKeys = ["id", "version", "environment"] as const;
+
+export interface ApiSchemaSnapshotDTO
+  extends Pick<ApiSchemaSnapshot, (typeof apiSchemaSnapshotDTOKeys)[number]> {}
+
+export const toApiSchemaSnapshotDTO = (apiSchemaSnapshot: ApiSchemaSnapshot): ApiSchemaSnapshotDTO =>
+  pickDTOFields(apiSchemaSnapshot, apiSchemaSnapshotDTOKeys);
+
+
+const apiEndpointDTOKeys = ["id", "description", "endpoint_hash"] as const;
+
+export interface ApiEndpointDTO
+  extends Pick<ApiEndpoint, (typeof apiEndpointDTOKeys)[number]> {}
+
+export const toApiEndpointDTO = (apiEndpoint: ApiEndpoint): ApiEndpointDTO =>
+  pickDTOFields(apiEndpoint, apiEndpointDTOKeys);
+
+
+const apiDiffDTOKeys = ["id", "diff_hash", "from_snapshot_id"] as const;
+
+export interface ApiDiffDTO
+  extends Pick<ApiDiff, (typeof apiDiffDTOKeys)[number]> {}
+
+export const toApiDiffDTO = (apiDiff: ApiDiff): ApiDiffDTO =>
+  pickDTOFields(apiDiff, apiDiffDTOKeys);
+
+
+const apiChangeEventDTOKeys = ["id", "title", "severity", "description"] as const;
+
+export interface ApiChangeEventDTO
+  extends Pick<ApiChangeEvent, (typeof apiChangeEventDTOKeys)[number]> {}
+
+export const toApiChangeEventDTO = (apiChangeEvent: ApiChangeEvent): ApiChangeEventDTO =>
+  pickDTOFields(apiChangeEvent, apiChangeEventDTOKeys);
+
+
+const apiMonitoringRuleDTOKeys = ["id", "rule_name", "module_filter"] as const;
+
+export interface ApiMonitoringRuleDTO
+  extends Pick<ApiMonitoringRule, (typeof apiMonitoringRuleDTOKeys)[number]> {}
+
+export const toApiMonitoringRuleDTO = (apiMonitoringRule: ApiMonitoringRule): ApiMonitoringRuleDTO =>
+  pickDTOFields(apiMonitoringRule, apiMonitoringRuleDTOKeys);
+
+
+const apiAlertHistoryDTOKeys = ["id", "title", "severity"] as const;
+
+export interface ApiAlertHistoryDTO
+  extends Pick<ApiAlertHistory, (typeof apiAlertHistoryDTOKeys)[number]> {}
+
+export const toApiAlertHistoryDTO = (apiAlertHistory: ApiAlertHistory): ApiAlertHistoryDTO =>
+  pickDTOFields(apiAlertHistory, apiAlertHistoryDTOKeys);
+
+
+const apiVersionHistoryDTOKeys = ["id", "version", "version_id"] as const;
+
+export interface ApiVersionHistoryDTO
+  extends Pick<ApiVersionHistory, (typeof apiVersionHistoryDTOKeys)[number]> {}
+
+export const toApiVersionHistoryDTO = (apiVersionHistory: ApiVersionHistory): ApiVersionHistoryDTO =>
+  pickDTOFields(apiVersionHistory, apiVersionHistoryDTOKeys);
+
+
+const apiRollbackOperationDTOKeys = ["id", "status", "operation_id"] as const;
+
+export interface ApiRollbackOperationDTO
+  extends Pick<ApiRollbackOperation, (typeof apiRollbackOperationDTOKeys)[number]> {}
+
+export const toApiRollbackOperationDTO = (apiRollbackOperation: ApiRollbackOperation): ApiRollbackOperationDTO =>
+  pickDTOFields(apiRollbackOperation, apiRollbackOperationDTOKeys);
+
+
+const apiExportOperationDTOKeys = ["id", "status", "export_id"] as const;
+
+export interface ApiExportOperationDTO
+  extends Pick<ApiExportOperation, (typeof apiExportOperationDTOKeys)[number]> {}
+
+export const toApiExportOperationDTO = (apiExportOperation: ApiExportOperation): ApiExportOperationDTO =>
+  pickDTOFields(apiExportOperation, apiExportOperationDTOKeys);
+
+
+const apiAnalyticsSummaryDTOKeys = ["id", "summary_id", "period_type"] as const;
+
+export interface ApiAnalyticsSummaryDTO
+  extends Pick<ApiAnalyticsSummary, (typeof apiAnalyticsSummaryDTOKeys)[number]> {}
+
+export const toApiAnalyticsSummaryDTO = (apiAnalyticsSummary: ApiAnalyticsSummary): ApiAnalyticsSummaryDTO =>
+  pickDTOFields(apiAnalyticsSummary, apiAnalyticsSummaryDTOKeys);
+

--- a/shared/apiKeysTables.ts
+++ b/shared/apiKeysTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, boolean, timestamp, integer } from "drizzle-orm/pg-core"
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // API Keys Management System
 export const apiKeys = pgTable("api_keys", {
   id: text("id").primaryKey(),
@@ -24,5 +26,16 @@ export const apiKeys = pgTable("api_keys", {
 export const insertApiKeySchema = createInsertSchema(apiKeys);
 export const selectApiKeySchema = createInsertSchema(apiKeys);
 
-export type InsertApiKey = z.infer<typeof insertApiKeySchema>;
+export type ApiKey = InferSelectModel<typeof apiKeys>;
+export type InsertApiKey = InferInsertModel<typeof apiKeys>;
 export type SelectApiKey = z.infer<typeof selectApiKeySchema>;
+
+// DTOs
+const apiKeyDTOKeys = ["id", "name", "category", "createdAt", "updatedAt", "description"] as const;
+
+export interface ApiKeyDTO
+  extends Pick<ApiKey, (typeof apiKeyDTOKeys)[number]> {}
+
+export const toApiKeyDTO = (apiKey: ApiKey): ApiKeyDTO =>
+  pickDTOFields(apiKey, apiKeyDTOKeys);
+

--- a/shared/chatbotTables.ts
+++ b/shared/chatbotTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // ================================================
 // REAL-TIME CHATBOT/ASSISTANT MODULE
 // Billion-Dollar Empire Grade, Migration-Proof, Full-Stack
@@ -248,25 +250,125 @@ export const insertCannedResponseSchema = createInsertSchema(cannedResponses);
 export const insertChatFeedbackSchema = createInsertSchema(chatFeedback);
 
 // Types
-export type ChatSession = typeof chatSessions.$inferSelect;
-export type NewChatSession = typeof chatSessions.$inferInsert;
-export type ChatMessage = typeof chatMessages.$inferSelect;
-export type NewChatMessage = typeof chatMessages.$inferInsert;
-export type ChatIntent = typeof chatIntents.$inferSelect;
-export type NewChatIntent = typeof chatIntents.$inferInsert;
-export type BotKnowledgeBase = typeof botKnowledgeBase.$inferSelect;
-export type NewBotKnowledgeBase = typeof botKnowledgeBase.$inferInsert;
-export type ConversationContext = typeof conversationContext.$inferSelect;
-export type NewConversationContext = typeof conversationContext.$inferInsert;
-export type ChatAnalytic = typeof chatAnalytics.$inferSelect;
-export type NewChatAnalytic = typeof chatAnalytics.$inferInsert;
-export type ChatWidget = typeof chatWidgets.$inferSelect;
-export type NewChatWidget = typeof chatWidgets.$inferInsert;
-export type HumanAgent = typeof humanAgents.$inferSelect;
-export type NewHumanAgent = typeof humanAgents.$inferInsert;
-export type ChatEscalation = typeof chatEscalations.$inferSelect;
-export type NewChatEscalation = typeof chatEscalations.$inferInsert;
-export type CannedResponse = typeof cannedResponses.$inferSelect;
-export type NewCannedResponse = typeof cannedResponses.$inferInsert;
-export type ChatFeedback = typeof chatFeedback.$inferSelect;
-export type NewChatFeedback = typeof chatFeedback.$inferInsert;
+export type ChatSession = InferSelectModel<typeof chatSessions>;
+export type NewChatSession = InferInsertModel<typeof chatSessions>;
+export type ChatMessage = InferSelectModel<typeof chatMessages>;
+export type NewChatMessage = InferInsertModel<typeof chatMessages>;
+export type ChatIntent = InferSelectModel<typeof chatIntents>;
+export type NewChatIntent = InferInsertModel<typeof chatIntents>;
+export type BotKnowledgeBase = InferSelectModel<typeof botKnowledgeBase>;
+export type NewBotKnowledgeBase = InferInsertModel<typeof botKnowledgeBase>;
+export type ConversationContext = InferSelectModel<typeof conversationContext>;
+export type NewConversationContext = InferInsertModel<typeof conversationContext>;
+export type ChatAnalytic = InferSelectModel<typeof chatAnalytics>;
+export type NewChatAnalytic = InferInsertModel<typeof chatAnalytics>;
+export type ChatWidget = InferSelectModel<typeof chatWidgets>;
+export type NewChatWidget = InferInsertModel<typeof chatWidgets>;
+export type HumanAgent = InferSelectModel<typeof humanAgents>;
+export type NewHumanAgent = InferInsertModel<typeof humanAgents>;
+export type ChatEscalation = InferSelectModel<typeof chatEscalations>;
+export type NewChatEscalation = InferInsertModel<typeof chatEscalations>;
+export type CannedResponse = InferSelectModel<typeof cannedResponses>;
+export type NewCannedResponse = InferInsertModel<typeof cannedResponses>;
+export type ChatFeedback = InferSelectModel<typeof chatFeedback>;
+export type NewChatFeedback = InferInsertModel<typeof chatFeedback>;
+
+// DTOs
+const chatSessionDTOKeys = ["id", "status", "sessionId", "userId", "language", "createdAt", "updatedAt"] as const;
+
+export interface ChatSessionDTO
+  extends Pick<ChatSession, (typeof chatSessionDTOKeys)[number]> {}
+
+export const toChatSessionDTO = (chatSession: ChatSession): ChatSessionDTO =>
+  pickDTOFields(chatSession, chatSessionDTOKeys);
+
+
+const chatMessageDTOKeys = ["id", "sessionId", "userId", "language", "createdAt", "updatedAt"] as const;
+
+export interface ChatMessageDTO
+  extends Pick<ChatMessage, (typeof chatMessageDTOKeys)[number]> {}
+
+export const toChatMessageDTO = (chatMessage: ChatMessage): ChatMessageDTO =>
+  pickDTOFields(chatMessage, chatMessageDTOKeys);
+
+
+const chatIntentDTOKeys = ["id", "priority", "createdAt", "updatedAt"] as const;
+
+export interface ChatIntentDTO
+  extends Pick<ChatIntent, (typeof chatIntentDTOKeys)[number]> {}
+
+export const toChatIntentDTO = (chatIntent: ChatIntent): ChatIntentDTO =>
+  pickDTOFields(chatIntent, chatIntentDTOKeys);
+
+
+const botKnowledgeBaseDTOKeys = ["id", "title", "category", "priority", "createdAt", "updatedAt"] as const;
+
+export interface BotKnowledgeBaseDTO
+  extends Pick<BotKnowledgeBase, (typeof botKnowledgeBaseDTOKeys)[number]> {}
+
+export const toBotKnowledgeBaseDTO = (botKnowledgeBase: BotKnowledgeBase): BotKnowledgeBaseDTO =>
+  pickDTOFields(botKnowledgeBase, botKnowledgeBaseDTOKeys);
+
+
+const conversationContextDTOKeys = ["id", "sessionId", "userId", "createdAt", "updatedAt"] as const;
+
+export interface ConversationContextDTO
+  extends Pick<ConversationContext, (typeof conversationContextDTOKeys)[number]> {}
+
+export const toConversationContextDTO = (conversationContext: ConversationContext): ConversationContextDTO =>
+  pickDTOFields(conversationContext, conversationContextDTOKeys);
+
+
+const chatAnalyticDTOKeys = ["id", "sessionId", "userId", "createdAt", "eventType"] as const;
+
+export interface ChatAnalyticDTO
+  extends Pick<ChatAnalytic, (typeof chatAnalyticDTOKeys)[number]> {}
+
+export const toChatAnalyticDTO = (chatAnalytic: ChatAnalytic): ChatAnalyticDTO =>
+  pickDTOFields(chatAnalytic, chatAnalyticDTOKeys);
+
+
+const chatWidgetDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface ChatWidgetDTO
+  extends Pick<ChatWidget, (typeof chatWidgetDTOKeys)[number]> {}
+
+export const toChatWidgetDTO = (chatWidget: ChatWidget): ChatWidgetDTO =>
+  pickDTOFields(chatWidget, chatWidgetDTOKeys);
+
+
+const humanAgentDTOKeys = ["id", "createdAt", "updatedAt", "email", "role"] as const;
+
+export interface HumanAgentDTO
+  extends Pick<HumanAgent, (typeof humanAgentDTOKeys)[number]> {}
+
+export const toHumanAgentDTO = (humanAgent: HumanAgent): HumanAgentDTO =>
+  pickDTOFields(humanAgent, humanAgentDTOKeys);
+
+
+const chatEscalationDTOKeys = ["id", "status", "sessionId", "priority", "createdAt", "updatedAt"] as const;
+
+export interface ChatEscalationDTO
+  extends Pick<ChatEscalation, (typeof chatEscalationDTOKeys)[number]> {}
+
+export const toChatEscalationDTO = (chatEscalation: ChatEscalation): ChatEscalationDTO =>
+  pickDTOFields(chatEscalation, chatEscalationDTOKeys);
+
+
+const cannedResponseDTOKeys = ["id", "title", "category", "createdAt", "updatedAt"] as const;
+
+export interface CannedResponseDTO
+  extends Pick<CannedResponse, (typeof cannedResponseDTOKeys)[number]> {}
+
+export const toCannedResponseDTO = (cannedResponse: CannedResponse): CannedResponseDTO =>
+  pickDTOFields(cannedResponse, cannedResponseDTOKeys);
+
+
+const chatFeedbackDTOKeys = ["id", "sessionId", "userId", "createdAt", "updatedAt"] as const;
+
+export interface ChatFeedbackDTO
+  extends Pick<ChatFeedback, (typeof chatFeedbackDTOKeys)[number]> {}
+
+export const toChatFeedbackDTO = (chatFeedback: ChatFeedback): ChatFeedbackDTO =>
+  pickDTOFields(chatFeedback, chatFeedbackDTOKeys);
+

--- a/shared/codexTables.ts
+++ b/shared/codexTables.ts
@@ -2,6 +2,8 @@ import { pgTable, serial, varchar, text, timestamp, jsonb, boolean, integer, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // ===========================================
 // CODEX AUDIT SYSTEM TABLES
 // ===========================================
@@ -290,16 +292,71 @@ export const insertCodexReportSchema = createInsertSchema(codexReports).omit({
 // TYPE EXPORTS
 // ===========================================
 
-export type CodexAudit = typeof codexAudits.$inferSelect;
-export type CodexIssue = typeof codexIssues.$inferSelect;
-export type CodexFix = typeof codexFixes.$inferSelect;
-export type CodexLearning = typeof codexLearning.$inferSelect;
-export type CodexSchedule = typeof codexSchedules.$inferSelect;
-export type CodexReport = typeof codexReports.$inferSelect;
+export type CodexAudit = InferSelectModel<typeof codexAudits>;
+export type CodexIssue = InferSelectModel<typeof codexIssues>;
+export type CodexFix = InferSelectModel<typeof codexFixes>;
+export type CodexLearning = InferSelectModel<typeof codexLearning>;
+export type CodexSchedule = InferSelectModel<typeof codexSchedules>;
+export type CodexReport = InferSelectModel<typeof codexReports>;
 
-export type InsertCodexAudit = z.infer<typeof insertCodexAuditSchema>;
-export type InsertCodexIssue = z.infer<typeof insertCodexIssueSchema>;
-export type InsertCodexFix = z.infer<typeof insertCodexFixSchema>;
-export type InsertCodexLearning = z.infer<typeof insertCodexLearningSchema>;
-export type InsertCodexSchedule = z.infer<typeof insertCodexScheduleSchema>;
-export type InsertCodexReport = z.infer<typeof insertCodexReportSchema>;
+export type InsertCodexAudit = InferInsertModel<typeof codexAudits>;
+export type InsertCodexIssue = InferInsertModel<typeof codexIssues>;
+export type InsertCodexFix = InferInsertModel<typeof codexFixes>;
+export type InsertCodexLearning = InferInsertModel<typeof codexLearning>;
+export type InsertCodexSchedule = InferInsertModel<typeof codexSchedules>;
+export type InsertCodexReport = InferInsertModel<typeof codexReports>;
+
+// DTOs
+const codexAuditDTOKeys = ["id", "status", "priority", "createdAt", "updatedAt"] as const;
+
+export interface CodexAuditDTO
+  extends Pick<CodexAudit, (typeof codexAuditDTOKeys)[number]> {}
+
+export const toCodexAuditDTO = (codexAudit: CodexAudit): CodexAuditDTO =>
+  pickDTOFields(codexAudit, codexAuditDTOKeys);
+
+
+const codexIssueDTOKeys = ["id", "title", "status", "type", "category", "severity", "createdAt", "updatedAt"] as const;
+
+export interface CodexIssueDTO
+  extends Pick<CodexIssue, (typeof codexIssueDTOKeys)[number]> {}
+
+export const toCodexIssueDTO = (codexIssue: CodexIssue): CodexIssueDTO =>
+  pickDTOFields(codexIssue, codexIssueDTOKeys);
+
+
+const codexFixDTOKeys = ["id", "status", "createdAt", "updatedAt"] as const;
+
+export interface CodexFixDTO
+  extends Pick<CodexFix, (typeof codexFixDTOKeys)[number]> {}
+
+export const toCodexFixDTO = (codexFix: CodexFix): CodexFixDTO =>
+  pickDTOFields(codexFix, codexFixDTOKeys);
+
+
+const codexLearningDTOKeys = ["id", "category", "createdAt", "updatedAt"] as const;
+
+export interface CodexLearningDTO
+  extends Pick<CodexLearning, (typeof codexLearningDTOKeys)[number]> {}
+
+export const toCodexLearningDTO = (codexLearning: CodexLearning): CodexLearningDTO =>
+  pickDTOFields(codexLearning, codexLearningDTOKeys);
+
+
+const codexScheduleDTOKeys = ["id", "name", "createdAt", "updatedAt", "description"] as const;
+
+export interface CodexScheduleDTO
+  extends Pick<CodexSchedule, (typeof codexScheduleDTOKeys)[number]> {}
+
+export const toCodexScheduleDTO = (codexSchedule: CodexSchedule): CodexScheduleDTO =>
+  pickDTOFields(codexSchedule, codexScheduleDTOKeys);
+
+
+const codexReportDTOKeys = ["id", "status", "createdAt", "updatedAt", "summary"] as const;
+
+export interface CodexReportDTO
+  extends Pick<CodexReport, (typeof codexReportDTOKeys)[number]> {}
+
+export const toCodexReportDTO = (codexReport: CodexReport): CodexReportDTO =>
+  pickDTOFields(codexReport, codexReportDTOKeys);
+

--- a/shared/complianceTables.ts
+++ b/shared/complianceTables.ts
@@ -1,3 +1,5 @@
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // Advanced Compliance/Privacy/Consent Engine - Database Tables
 import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, decimal, uuid } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
@@ -453,26 +455,99 @@ export const insertComplianceRbacManagementSchema = createInsertSchema(complianc
 });
 
 // Type exports
-export type GlobalConsentManagement = typeof globalConsentManagement.$inferSelect;
-export type InsertGlobalConsentManagement = z.infer<typeof insertGlobalConsentManagementSchema>;
+export type GlobalConsentManagement = InferSelectModel<typeof globalConsentManagement>;
+export type InsertGlobalConsentManagement = InferInsertModel<typeof globalConsentManagement>;
 
-export type PrivacyPolicyManagement = typeof privacyPolicyManagement.$inferSelect;
-export type InsertPrivacyPolicyManagement = z.infer<typeof insertPrivacyPolicyManagementSchema>;
+export type PrivacyPolicyManagement = InferSelectModel<typeof privacyPolicyManagement>;
+export type InsertPrivacyPolicyManagement = InferInsertModel<typeof privacyPolicyManagement>;
 
-export type UserDataControlRequests = typeof userDataControlRequests.$inferSelect;
-export type InsertUserDataControlRequests = z.infer<typeof insertUserDataControlRequestsSchema>;
+export type UserDataControlRequests = InferSelectModel<typeof userDataControlRequests>;
+export type InsertUserDataControlRequests = InferInsertModel<typeof userDataControlRequests>;
 
-export type AffiliateComplianceManagement = typeof affiliateComplianceManagement.$inferSelect;
-export type InsertAffiliateComplianceManagement = z.infer<typeof insertAffiliateComplianceManagementSchema>;
+export type AffiliateComplianceManagement = InferSelectModel<typeof affiliateComplianceManagement>;
+export type InsertAffiliateComplianceManagement = InferInsertModel<typeof affiliateComplianceManagement>;
 
-export type ComplianceAuditSystem = typeof complianceAuditSystem.$inferSelect;
-export type InsertComplianceAuditSystem = z.infer<typeof insertComplianceAuditSystemSchema>;
+export type ComplianceAuditSystem = InferSelectModel<typeof complianceAuditSystem>;
+export type InsertComplianceAuditSystem = InferInsertModel<typeof complianceAuditSystem>;
 
-export type GeoRestrictionManagement = typeof geoRestrictionManagement.$inferSelect;
-export type InsertGeoRestrictionManagement = z.infer<typeof insertGeoRestrictionManagementSchema>;
+export type GeoRestrictionManagement = InferSelectModel<typeof geoRestrictionManagement>;
+export type InsertGeoRestrictionManagement = InferInsertModel<typeof geoRestrictionManagement>;
 
-export type ComplianceRbacManagement = typeof complianceRbacManagement.$inferSelect;
-export type InsertComplianceRbacManagement = z.infer<typeof insertComplianceRbacManagementSchema>;
+export type ComplianceRbacManagement = InferSelectModel<typeof complianceRbacManagement>;
+export type InsertComplianceRbacManagement = InferInsertModel<typeof complianceRbacManagement>;
 
-export type ModerationRules = typeof moderationRules.$inferSelect;
-export type InsertModerationRules = z.infer<typeof insertModerationRulesSchema>;
+export type ModerationRules = InferSelectModel<typeof moderationRules>;
+export type InsertModerationRules = InferInsertModel<typeof moderationRules>;
+
+// DTOs
+const globalConsentManagementDTOKeys = ["id", "sessionId", "userId", "region", "country", "createdAt", "updatedAt"] as const;
+
+export interface GlobalConsentManagementDTO
+  extends Pick<GlobalConsentManagement, (typeof globalConsentManagementDTOKeys)[number]> {}
+
+export const toGlobalConsentManagementDTO = (globalConsentManagement: GlobalConsentManagement): GlobalConsentManagementDTO =>
+  pickDTOFields(globalConsentManagement, globalConsentManagementDTOKeys);
+
+
+const privacyPolicyManagementDTOKeys = ["id", "title", "status", "vertical", "country", "language", "createdAt", "updatedAt"] as const;
+
+export interface PrivacyPolicyManagementDTO
+  extends Pick<PrivacyPolicyManagement, (typeof privacyPolicyManagementDTOKeys)[number]> {}
+
+export const toPrivacyPolicyManagementDTO = (privacyPolicyManagement: PrivacyPolicyManagement): PrivacyPolicyManagementDTO =>
+  pickDTOFields(privacyPolicyManagement, privacyPolicyManagementDTOKeys);
+
+
+const userDataControlRequestsDTOKeys = ["id", "status", "userId", "priority", "createdAt", "updatedAt", "description", "email"] as const;
+
+export interface UserDataControlRequestsDTO
+  extends Pick<UserDataControlRequests, (typeof userDataControlRequestsDTOKeys)[number]> {}
+
+export const toUserDataControlRequestsDTO = (userDataControlRequests: UserDataControlRequests): UserDataControlRequestsDTO =>
+  pickDTOFields(userDataControlRequests, userDataControlRequestsDTOKeys);
+
+
+const affiliateComplianceManagementDTOKeys = ["id", "status", "createdAt", "updatedAt"] as const;
+
+export interface AffiliateComplianceManagementDTO
+  extends Pick<AffiliateComplianceManagement, (typeof affiliateComplianceManagementDTOKeys)[number]> {}
+
+export const toAffiliateComplianceManagementDTO = (affiliateComplianceManagement: AffiliateComplianceManagement): AffiliateComplianceManagementDTO =>
+  pickDTOFields(affiliateComplianceManagement, affiliateComplianceManagementDTOKeys);
+
+
+const complianceAuditSystemDTOKeys = ["id", "status", "vertical", "country", "createdAt", "updatedAt"] as const;
+
+export interface ComplianceAuditSystemDTO
+  extends Pick<ComplianceAuditSystem, (typeof complianceAuditSystemDTOKeys)[number]> {}
+
+export const toComplianceAuditSystemDTO = (complianceAuditSystem: ComplianceAuditSystem): ComplianceAuditSystemDTO =>
+  pickDTOFields(complianceAuditSystem, complianceAuditSystemDTOKeys);
+
+
+const geoRestrictionManagementDTOKeys = ["id", "status", "ruleId", "priority", "createdAt", "updatedAt"] as const;
+
+export interface GeoRestrictionManagementDTO
+  extends Pick<GeoRestrictionManagement, (typeof geoRestrictionManagementDTOKeys)[number]> {}
+
+export const toGeoRestrictionManagementDTO = (geoRestrictionManagement: GeoRestrictionManagement): GeoRestrictionManagementDTO =>
+  pickDTOFields(geoRestrictionManagement, geoRestrictionManagementDTOKeys);
+
+
+const complianceRbacManagementDTOKeys = ["id", "status", "userId", "createdAt", "updatedAt"] as const;
+
+export interface ComplianceRbacManagementDTO
+  extends Pick<ComplianceRbacManagement, (typeof complianceRbacManagementDTOKeys)[number]> {}
+
+export const toComplianceRbacManagementDTO = (complianceRbacManagement: ComplianceRbacManagement): ComplianceRbacManagementDTO =>
+  pickDTOFields(complianceRbacManagement, complianceRbacManagementDTOKeys);
+
+
+const moderationRulesDTOKeys = ["id", "name", "type", "severity", "createdAt"] as const;
+
+export interface ModerationRulesDTO
+  extends Pick<ModerationRules, (typeof moderationRulesDTOKeys)[number]> {}
+
+export const toModerationRulesDTO = (moderationRules: ModerationRules): ModerationRulesDTO =>
+  pickDTOFields(moderationRules, moderationRulesDTOKeys);
+

--- a/shared/configTables.ts
+++ b/shared/configTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, uui
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // ==========================================
 // CENTRAL CONFIG ENGINE - ENTERPRISE SCHEMA
 // ==========================================
@@ -313,26 +315,99 @@ export const insertConfigAiMetadataSchema = createInsertSchema(configAiMetadata)
 // TYPE EXPORTS
 // ==========================================
 
-export type ConfigRegistry = typeof configRegistry.$inferSelect;
-export type InsertConfigRegistry = z.infer<typeof insertConfigRegistrySchema>;
+export type ConfigRegistry = InferSelectModel<typeof configRegistry>;
+export type InsertConfigRegistry = InferInsertModel<typeof configRegistry>;
 
-export type ConfigChangeHistory = typeof configChangeHistory.$inferSelect;
-export type InsertConfigChangeHistory = z.infer<typeof insertConfigChangeHistorySchema>;
+export type ConfigChangeHistory = InferSelectModel<typeof configChangeHistory>;
+export type InsertConfigChangeHistory = InferInsertModel<typeof configChangeHistory>;
 
-export type ConfigSnapshot = typeof configSnapshots.$inferSelect;
-export type InsertConfigSnapshot = z.infer<typeof insertConfigSnapshotSchema>;
+export type ConfigSnapshot = InferSelectModel<typeof configSnapshots>;
+export type InsertConfigSnapshot = InferInsertModel<typeof configSnapshots>;
 
-export type ConfigPermission = typeof configPermissions.$inferSelect;
-export type InsertConfigPermission = z.infer<typeof insertConfigPermissionSchema>;
+export type ConfigPermission = InferSelectModel<typeof configPermissions>;
+export type InsertConfigPermission = InferInsertModel<typeof configPermissions>;
 
-export type ConfigFederationSync = typeof configFederationSync.$inferSelect;
-export type InsertConfigFederationSync = z.infer<typeof insertConfigFederationSyncSchema>;
+export type ConfigFederationSync = InferSelectModel<typeof configFederationSync>;
+export type InsertConfigFederationSync = InferInsertModel<typeof configFederationSync>;
 
-export type ConfigPerformanceMetric = typeof configPerformanceMetrics.$inferSelect;
-export type InsertConfigPerformanceMetric = z.infer<typeof insertConfigPerformanceMetricSchema>;
+export type ConfigPerformanceMetric = InferSelectModel<typeof configPerformanceMetrics>;
+export type InsertConfigPerformanceMetric = InferInsertModel<typeof configPerformanceMetrics>;
 
-export type ConfigValidationRule = typeof configValidationRules.$inferSelect;
-export type InsertConfigValidationRule = z.infer<typeof insertConfigValidationRuleSchema>;
+export type ConfigValidationRule = InferSelectModel<typeof configValidationRules>;
+export type InsertConfigValidationRule = InferInsertModel<typeof configValidationRules>;
 
-export type ConfigAiMetadata = typeof configAiMetadata.$inferSelect;
-export type InsertConfigAiMetadata = z.infer<typeof insertConfigAiMetadataSchema>;
+export type ConfigAiMetadata = InferSelectModel<typeof configAiMetadata>;
+export type InsertConfigAiMetadata = InferInsertModel<typeof configAiMetadata>;
+
+// DTOs
+const configRegistryDTOKeys = ["id", "title", "category", "vertical", "locale", "createdAt", "updatedAt", "description"] as const;
+
+export interface ConfigRegistryDTO
+  extends Pick<ConfigRegistry, (typeof configRegistryDTOKeys)[number]> {}
+
+export const toConfigRegistryDTO = (configRegistry: ConfigRegistry): ConfigRegistryDTO =>
+  pickDTOFields(configRegistry, configRegistryDTOKeys);
+
+
+const configChangeHistoryDTOKeys = ["id", "userId", "createdAt", "source"] as const;
+
+export interface ConfigChangeHistoryDTO
+  extends Pick<ConfigChangeHistory, (typeof configChangeHistoryDTOKeys)[number]> {}
+
+export const toConfigChangeHistoryDTO = (configChangeHistory: ConfigChangeHistory): ConfigChangeHistoryDTO =>
+  pickDTOFields(configChangeHistory, configChangeHistoryDTOKeys);
+
+
+const configSnapshotDTOKeys = ["id", "createdAt", "description", "version"] as const;
+
+export interface ConfigSnapshotDTO
+  extends Pick<ConfigSnapshot, (typeof configSnapshotDTOKeys)[number]> {}
+
+export const toConfigSnapshotDTO = (configSnapshot: ConfigSnapshot): ConfigSnapshotDTO =>
+  pickDTOFields(configSnapshot, configSnapshotDTOKeys);
+
+
+const configPermissionDTOKeys = ["id", "userId", "createdAt", "updatedAt", "teamId"] as const;
+
+export interface ConfigPermissionDTO
+  extends Pick<ConfigPermission, (typeof configPermissionDTOKeys)[number]> {}
+
+export const toConfigPermissionDTO = (configPermission: ConfigPermission): ConfigPermissionDTO =>
+  pickDTOFields(configPermission, configPermissionDTOKeys);
+
+
+const configFederationSyncDTOKeys = ["id", "neuronId", "syncId"] as const;
+
+export interface ConfigFederationSyncDTO
+  extends Pick<ConfigFederationSync, (typeof configFederationSyncDTOKeys)[number]> {}
+
+export const toConfigFederationSyncDTO = (configFederationSync: ConfigFederationSync): ConfigFederationSyncDTO =>
+  pickDTOFields(configFederationSync, configFederationSyncDTOKeys);
+
+
+const configPerformanceMetricDTOKeys = ["id", "region", "environment"] as const;
+
+export interface ConfigPerformanceMetricDTO
+  extends Pick<ConfigPerformanceMetric, (typeof configPerformanceMetricDTOKeys)[number]> {}
+
+export const toConfigPerformanceMetricDTO = (configPerformanceMetric: ConfigPerformanceMetric): ConfigPerformanceMetricDTO =>
+  pickDTOFields(configPerformanceMetric, configPerformanceMetricDTOKeys);
+
+
+const configValidationRuleDTOKeys = ["id", "name", "category", "ruleId", "severity", "createdAt", "updatedAt", "description"] as const;
+
+export interface ConfigValidationRuleDTO
+  extends Pick<ConfigValidationRule, (typeof configValidationRuleDTOKeys)[number]> {}
+
+export const toConfigValidationRuleDTO = (configValidationRule: ConfigValidationRule): ConfigValidationRuleDTO =>
+  pickDTOFields(configValidationRule, configValidationRuleDTOKeys);
+
+
+const configAiMetadataDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface ConfigAiMetadataDTO
+  extends Pick<ConfigAiMetadata, (typeof configAiMetadataDTOKeys)[number]> {}
+
+export const toConfigAiMetadataDTO = (configAiMetadata: ConfigAiMetadata): ConfigAiMetadataDTO =>
+  pickDTOFields(configAiMetadata, configAiMetadataDTOKeys);
+

--- a/shared/contentDefenderTables.ts
+++ b/shared/contentDefenderTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // ================================================
 // AI CONTENT DEFENDER & PLAGIARISM WATCHDOG MODULE
 // Billion-Dollar Empire Grade, Migration-Proof, DMCA-Ready
@@ -219,19 +221,92 @@ export const insertSeoCounterAttackSchema = createInsertSchema(seoCounterAttacks
 export const insertContentDefenseAnalyticsSchema = createInsertSchema(contentDefenseAnalytics);
 
 // Types
-export type ContentInventory = typeof contentInventory.$inferSelect;
-export type NewContentInventory = typeof contentInventory.$inferInsert;
-export type PlagiarismDetection = typeof plagiarismDetections.$inferSelect;
-export type NewPlagiarismDetection = typeof plagiarismDetections.$inferInsert;
-export type DmcaRequest = typeof dmcaRequests.$inferSelect;
-export type NewDmcaRequest = typeof dmcaRequests.$inferInsert;
-export type ContentRefresh = typeof contentRefreshes.$inferSelect;
-export type NewContentRefresh = typeof contentRefreshes.$inferInsert;
-export type ScraperDetection = typeof scraperDetections.$inferSelect;
-export type NewScraperDetection = typeof scraperDetections.$inferInsert;
-export type ContentMonitoringJob = typeof contentMonitoringJobs.$inferSelect;
-export type NewContentMonitoringJob = typeof contentMonitoringJobs.$inferInsert;
-export type SeoCounterAttack = typeof seoCounterAttacks.$inferSelect;
-export type NewSeoCounterAttack = typeof seoCounterAttacks.$inferInsert;
-export type ContentDefenseAnalytic = typeof contentDefenseAnalytics.$inferSelect;
-export type NewContentDefenseAnalytic = typeof contentDefenseAnalytics.$inferInsert;
+export type ContentInventory = InferSelectModel<typeof contentInventory>;
+export type NewContentInventory = InferInsertModel<typeof contentInventory>;
+export type PlagiarismDetection = InferSelectModel<typeof plagiarismDetections>;
+export type NewPlagiarismDetection = InferInsertModel<typeof plagiarismDetections>;
+export type DmcaRequest = InferSelectModel<typeof dmcaRequests>;
+export type NewDmcaRequest = InferInsertModel<typeof dmcaRequests>;
+export type ContentRefresh = InferSelectModel<typeof contentRefreshes>;
+export type NewContentRefresh = InferInsertModel<typeof contentRefreshes>;
+export type ScraperDetection = InferSelectModel<typeof scraperDetections>;
+export type NewScraperDetection = InferInsertModel<typeof scraperDetections>;
+export type ContentMonitoringJob = InferSelectModel<typeof contentMonitoringJobs>;
+export type NewContentMonitoringJob = InferInsertModel<typeof contentMonitoringJobs>;
+export type SeoCounterAttack = InferSelectModel<typeof seoCounterAttacks>;
+export type NewSeoCounterAttack = InferInsertModel<typeof seoCounterAttacks>;
+export type ContentDefenseAnalytic = InferSelectModel<typeof contentDefenseAnalytics>;
+export type NewContentDefenseAnalytic = InferInsertModel<typeof contentDefenseAnalytics>;
+
+// DTOs
+const contentInventoryDTOKeys = ["id", "neuronId", "vertical", "createdAt", "updatedAt"] as const;
+
+export interface ContentInventoryDTO
+  extends Pick<ContentInventory, (typeof contentInventoryDTOKeys)[number]> {}
+
+export const toContentInventoryDTO = (contentInventory: ContentInventory): ContentInventoryDTO =>
+  pickDTOFields(contentInventory, contentInventoryDTOKeys);
+
+
+const plagiarismDetectionDTOKeys = ["id", "status", "priority", "createdAt", "updatedAt"] as const;
+
+export interface PlagiarismDetectionDTO
+  extends Pick<PlagiarismDetection, (typeof plagiarismDetectionDTOKeys)[number]> {}
+
+export const toPlagiarismDetectionDTO = (plagiarismDetection: PlagiarismDetection): PlagiarismDetectionDTO =>
+  pickDTOFields(plagiarismDetection, plagiarismDetectionDTOKeys);
+
+
+const dmcaRequestDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface DmcaRequestDTO
+  extends Pick<DmcaRequest, (typeof dmcaRequestDTOKeys)[number]> {}
+
+export const toDmcaRequestDTO = (dmcaRequest: DmcaRequest): DmcaRequestDTO =>
+  pickDTOFields(dmcaRequest, dmcaRequestDTOKeys);
+
+
+const contentRefreshDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface ContentRefreshDTO
+  extends Pick<ContentRefresh, (typeof contentRefreshDTOKeys)[number]> {}
+
+export const toContentRefreshDTO = (contentRefresh: ContentRefresh): ContentRefreshDTO =>
+  pickDTOFields(contentRefresh, contentRefreshDTOKeys);
+
+
+const scraperDetectionDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface ScraperDetectionDTO
+  extends Pick<ScraperDetection, (typeof scraperDetectionDTOKeys)[number]> {}
+
+export const toScraperDetectionDTO = (scraperDetection: ScraperDetection): ScraperDetectionDTO =>
+  pickDTOFields(scraperDetection, scraperDetectionDTOKeys);
+
+
+const contentMonitoringJobDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface ContentMonitoringJobDTO
+  extends Pick<ContentMonitoringJob, (typeof contentMonitoringJobDTOKeys)[number]> {}
+
+export const toContentMonitoringJobDTO = (contentMonitoringJob: ContentMonitoringJob): ContentMonitoringJobDTO =>
+  pickDTOFields(contentMonitoringJob, contentMonitoringJobDTOKeys);
+
+
+const seoCounterAttackDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface SeoCounterAttackDTO
+  extends Pick<SeoCounterAttack, (typeof seoCounterAttackDTOKeys)[number]> {}
+
+export const toSeoCounterAttackDTO = (seoCounterAttack: SeoCounterAttack): SeoCounterAttackDTO =>
+  pickDTOFields(seoCounterAttack, seoCounterAttackDTOKeys);
+
+
+const contentDefenseAnalyticDTOKeys = ["id", "createdAt", "eventType"] as const;
+
+export interface ContentDefenseAnalyticDTO
+  extends Pick<ContentDefenseAnalytic, (typeof contentDefenseAnalyticDTOKeys)[number]> {}
+
+export const toContentDefenseAnalyticDTO = (contentDefenseAnalytic: ContentDefenseAnalytic): ContentDefenseAnalyticDTO =>
+  pickDTOFields(contentDefenseAnalytic, contentDefenseAnalyticDTOKeys);
+

--- a/shared/contentFeedTables.ts
+++ b/shared/contentFeedTables.ts
@@ -1,3 +1,5 @@
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // Content & Offer Feed Engine - Database Tables
 import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, decimal, uuid } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
@@ -249,32 +251,123 @@ export const insertContentFeedNotificationSchema = createInsertSchema(contentFee
 });
 
 // Types
-export type ContentFeedSource = typeof contentFeedSources.$inferSelect;
-export type InsertContentFeedSource = z.infer<typeof insertContentFeedSourceSchema>;
+export type ContentFeedSource = InferSelectModel<typeof contentFeedSources>;
+export type InsertContentFeedSource = InferInsertModel<typeof contentFeedSources>;
 
-export type ContentFeed = typeof contentFeed.$inferSelect;
-export type InsertContentFeed = z.infer<typeof insertContentFeedSchema>;
+export type ContentFeed = InferSelectModel<typeof contentFeed>;
+export type InsertContentFeed = InferInsertModel<typeof contentFeed>;
 
-export type ContentFeedCategory = typeof contentFeedCategories.$inferSelect;
-export type InsertContentFeedCategory = z.infer<typeof insertContentFeedCategorySchema>;
+export type ContentFeedCategory = InferSelectModel<typeof contentFeedCategories>;
+export type InsertContentFeedCategory = InferInsertModel<typeof contentFeedCategories>;
 
-export type ContentFeedSyncLog = typeof contentFeedSyncLogs.$inferSelect;
-export type InsertContentFeedSyncLog = z.infer<typeof insertContentFeedSyncLogSchema>;
+export type ContentFeedSyncLog = InferSelectModel<typeof contentFeedSyncLogs>;
+export type InsertContentFeedSyncLog = InferInsertModel<typeof contentFeedSyncLogs>;
 
-export type ContentFeedRule = typeof contentFeedRules.$inferSelect;
-export type InsertContentFeedRule = z.infer<typeof insertContentFeedRuleSchema>;
+export type ContentFeedRule = InferSelectModel<typeof contentFeedRules>;
+export type InsertContentFeedRule = InferInsertModel<typeof contentFeedRules>;
 
-export type ContentFeedAnalytics = typeof contentFeedAnalytics.$inferSelect;
-export type InsertContentFeedAnalytics = z.infer<typeof insertContentFeedAnalyticsSchema>;
+export type ContentFeedAnalytics = InferSelectModel<typeof contentFeedAnalytics>;
+export type InsertContentFeedAnalytics = InferInsertModel<typeof contentFeedAnalytics>;
 
-export type ContentFeedInteraction = typeof contentFeedInteractions.$inferSelect;
-export type InsertContentFeedInteraction = z.infer<typeof insertContentFeedInteractionSchema>;
+export type ContentFeedInteraction = InferSelectModel<typeof contentFeedInteractions>;
+export type InsertContentFeedInteraction = InferInsertModel<typeof contentFeedInteractions>;
 
-export type ContentFeedNotification = typeof contentFeedNotifications.$inferSelect;
-export type InsertContentFeedNotification = z.infer<typeof insertContentFeedNotificationSchema>;
+export type ContentFeedNotification = InferSelectModel<typeof contentFeedNotifications>;
+export type InsertContentFeedNotification = InferInsertModel<typeof contentFeedNotifications>;
 
-export type MediaContacts = typeof mediaContacts.$inferSelect;
-export type InsertMediaContacts = z.infer<typeof insertMediaContactsSchema>;
+export type MediaContacts = InferSelectModel<typeof mediaContacts>;
+export type InsertMediaContacts = InferInsertModel<typeof mediaContacts>;
 
-export type OutreachTemplates = typeof outreachTemplates.$inferSelect;
-export type InsertOutreachTemplates = z.infer<typeof insertOutreachTemplatesSchema>;
+export type OutreachTemplates = InferSelectModel<typeof outreachTemplates>;
+export type InsertOutreachTemplates = InferInsertModel<typeof outreachTemplates>;
+
+// DTOs
+const contentFeedSourceDTOKeys = ["id", "name", "createdAt", "updatedAt"] as const;
+
+export interface ContentFeedSourceDTO
+  extends Pick<ContentFeedSource, (typeof contentFeedSourceDTOKeys)[number]> {}
+
+export const toContentFeedSourceDTO = (contentFeedSource: ContentFeedSource): ContentFeedSourceDTO =>
+  pickDTOFields(contentFeedSource, contentFeedSourceDTOKeys);
+
+
+const contentFeedDTOKeys = ["id", "title", "status", "category", "createdAt", "updatedAt", "description"] as const;
+
+export interface ContentFeedDTO
+  extends Pick<ContentFeed, (typeof contentFeedDTOKeys)[number]> {}
+
+export const toContentFeedDTO = (contentFeed: ContentFeed): ContentFeedDTO =>
+  pickDTOFields(contentFeed, contentFeedDTOKeys);
+
+
+const contentFeedCategoryDTOKeys = ["id", "name", "slug", "createdAt", "description"] as const;
+
+export interface ContentFeedCategoryDTO
+  extends Pick<ContentFeedCategory, (typeof contentFeedCategoryDTOKeys)[number]> {}
+
+export const toContentFeedCategoryDTO = (contentFeedCategory: ContentFeedCategory): ContentFeedCategoryDTO =>
+  pickDTOFields(contentFeedCategory, contentFeedCategoryDTOKeys);
+
+
+const contentFeedSyncLogDTOKeys = ["id", "status", "sourceId"] as const;
+
+export interface ContentFeedSyncLogDTO
+  extends Pick<ContentFeedSyncLog, (typeof contentFeedSyncLogDTOKeys)[number]> {}
+
+export const toContentFeedSyncLogDTO = (contentFeedSyncLog: ContentFeedSyncLog): ContentFeedSyncLogDTO =>
+  pickDTOFields(contentFeedSyncLog, contentFeedSyncLogDTOKeys);
+
+
+const contentFeedRuleDTOKeys = ["id", "name", "priority", "createdAt", "updatedAt"] as const;
+
+export interface ContentFeedRuleDTO
+  extends Pick<ContentFeedRule, (typeof contentFeedRuleDTOKeys)[number]> {}
+
+export const toContentFeedRuleDTO = (contentFeedRule: ContentFeedRule): ContentFeedRuleDTO =>
+  pickDTOFields(contentFeedRule, contentFeedRuleDTOKeys);
+
+
+const contentFeedAnalyticsDTOKeys = ["id", "createdAt", "metric"] as const;
+
+export interface ContentFeedAnalyticsDTO
+  extends Pick<ContentFeedAnalytics, (typeof contentFeedAnalyticsDTOKeys)[number]> {}
+
+export const toContentFeedAnalyticsDTO = (contentFeedAnalytics: ContentFeedAnalytics): ContentFeedAnalyticsDTO =>
+  pickDTOFields(contentFeedAnalytics, contentFeedAnalyticsDTOKeys);
+
+
+const contentFeedInteractionDTOKeys = ["id", "sessionId", "userId", "createdAt"] as const;
+
+export interface ContentFeedInteractionDTO
+  extends Pick<ContentFeedInteraction, (typeof contentFeedInteractionDTOKeys)[number]> {}
+
+export const toContentFeedInteractionDTO = (contentFeedInteraction: ContentFeedInteraction): ContentFeedInteractionDTO =>
+  pickDTOFields(contentFeedInteraction, contentFeedInteractionDTOKeys);
+
+
+const contentFeedNotificationDTOKeys = ["id", "title", "severity", "createdAt"] as const;
+
+export interface ContentFeedNotificationDTO
+  extends Pick<ContentFeedNotification, (typeof contentFeedNotificationDTOKeys)[number]> {}
+
+export const toContentFeedNotificationDTO = (contentFeedNotification: ContentFeedNotification): ContentFeedNotificationDTO =>
+  pickDTOFields(contentFeedNotification, contentFeedNotificationDTOKeys);
+
+
+const mediaContactsDTOKeys = ["id", "name", "createdAt", "updatedAt", "email"] as const;
+
+export interface MediaContactsDTO
+  extends Pick<MediaContacts, (typeof mediaContactsDTOKeys)[number]> {}
+
+export const toMediaContactsDTO = (mediaContacts: MediaContacts): MediaContactsDTO =>
+  pickDTOFields(mediaContacts, mediaContactsDTOKeys);
+
+
+const outreachTemplatesDTOKeys = ["id", "name", "type", "createdAt", "updatedAt"] as const;
+
+export interface OutreachTemplatesDTO
+  extends Pick<OutreachTemplates, (typeof outreachTemplatesDTOKeys)[number]> {}
+
+export const toOutreachTemplatesDTO = (outreachTemplates: OutreachTemplates): OutreachTemplatesDTO =>
+  pickDTOFields(outreachTemplates, outreachTemplatesDTOKeys);
+

--- a/shared/ctaRendererTables.ts
+++ b/shared/ctaRendererTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // 3D/AR/VR CTA Templates - Core template definitions
 export const ctaTemplates = pgTable("cta_templates", {
   id: serial("id").primaryKey(),
@@ -287,18 +289,82 @@ export const insertCtaAssetSchema = createInsertSchema(ctaAssets);
 export const insertCtaUserSessionSchema = createInsertSchema(ctaUserSessions);
 export const insertCtaComplianceSchema = createInsertSchema(ctaCompliance);
 
-export type InsertCtaTemplate = z.infer<typeof insertCtaTemplateSchema>;
-export type InsertCtaInstance = z.infer<typeof insertCtaInstanceSchema>;
-export type InsertCtaAnalytics = z.infer<typeof insertCtaAnalyticsSchema>;
-export type InsertCtaAbTest = z.infer<typeof insertCtaAbTestSchema>;
-export type InsertCtaAsset = z.infer<typeof insertCtaAssetSchema>;
-export type InsertCtaUserSession = z.infer<typeof insertCtaUserSessionSchema>;
-export type InsertCtaCompliance = z.infer<typeof insertCtaComplianceSchema>;
+export type InsertCtaTemplate = InferInsertModel<typeof ctaTemplates>;
+export type InsertCtaInstance = InferInsertModel<typeof ctaInstances>;
+export type InsertCtaAnalytics = InferInsertModel<typeof ctaAnalytics>;
+export type InsertCtaAbTest = InferInsertModel<typeof ctaAbTests>;
+export type InsertCtaAsset = InferInsertModel<typeof ctaAssets>;
+export type InsertCtaUserSession = InferInsertModel<typeof ctaUserSessions>;
+export type InsertCtaCompliance = InferInsertModel<typeof ctaCompliance>;
 
-export type CtaTemplate = typeof ctaTemplates.$inferSelect;
-export type CtaInstance = typeof ctaInstances.$inferSelect;
-export type CtaAnalytics = typeof ctaAnalytics.$inferSelect;
-export type CtaAbTest = typeof ctaAbTests.$inferSelect;
-export type CtaAsset = typeof ctaAssets.$inferSelect;
-export type CtaUserSession = typeof ctaUserSessions.$inferSelect;
-export type CtaCompliance = typeof ctaCompliance.$inferSelect;
+export type CtaTemplate = InferSelectModel<typeof ctaTemplates>;
+export type CtaInstance = InferSelectModel<typeof ctaInstances>;
+export type CtaAnalytics = InferSelectModel<typeof ctaAnalytics>;
+export type CtaAbTest = InferSelectModel<typeof ctaAbTests>;
+export type CtaAsset = InferSelectModel<typeof ctaAssets>;
+export type CtaUserSession = InferSelectModel<typeof ctaUserSessions>;
+export type CtaCompliance = InferSelectModel<typeof ctaCompliance>;
+
+// DTOs
+const ctaTemplateDTOKeys = ["id", "name", "type", "category", "createdAt", "updatedAt", "description", "version"] as const;
+
+export interface CtaTemplateDTO
+  extends Pick<CtaTemplate, (typeof ctaTemplateDTOKeys)[number]> {}
+
+export const toCtaTemplateDTO = (ctaTemplate: CtaTemplate): CtaTemplateDTO =>
+  pickDTOFields(ctaTemplate, ctaTemplateDTOKeys);
+
+
+const ctaInstanceDTOKeys = ["id", "name", "status", "neuronId", "createdAt", "updatedAt", "description"] as const;
+
+export interface CtaInstanceDTO
+  extends Pick<CtaInstance, (typeof ctaInstanceDTOKeys)[number]> {}
+
+export const toCtaInstanceDTO = (ctaInstance: CtaInstance): CtaInstanceDTO =>
+  pickDTOFields(ctaInstance, ctaInstanceDTOKeys);
+
+
+const ctaAnalyticsDTOKeys = ["id", "sessionId", "userId", "createdAt", "eventType"] as const;
+
+export interface CtaAnalyticsDTO
+  extends Pick<CtaAnalytics, (typeof ctaAnalyticsDTOKeys)[number]> {}
+
+export const toCtaAnalyticsDTO = (ctaAnalytics: CtaAnalytics): CtaAnalyticsDTO =>
+  pickDTOFields(ctaAnalytics, ctaAnalyticsDTOKeys);
+
+
+const ctaAbTestDTOKeys = ["id", "name", "status", "createdAt", "updatedAt", "description"] as const;
+
+export interface CtaAbTestDTO
+  extends Pick<CtaAbTest, (typeof ctaAbTestDTOKeys)[number]> {}
+
+export const toCtaAbTestDTO = (ctaAbTest: CtaAbTest): CtaAbTestDTO =>
+  pickDTOFields(ctaAbTest, ctaAbTestDTOKeys);
+
+
+const ctaAssetDTOKeys = ["id", "name", "type", "category", "createdAt", "updatedAt", "description"] as const;
+
+export interface CtaAssetDTO
+  extends Pick<CtaAsset, (typeof ctaAssetDTOKeys)[number]> {}
+
+export const toCtaAssetDTO = (ctaAsset: CtaAsset): CtaAssetDTO =>
+  pickDTOFields(ctaAsset, ctaAssetDTOKeys);
+
+
+const ctaUserSessionDTOKeys = ["id", "sessionId", "userId", "createdAt", "updatedAt"] as const;
+
+export interface CtaUserSessionDTO
+  extends Pick<CtaUserSession, (typeof ctaUserSessionDTOKeys)[number]> {}
+
+export const toCtaUserSessionDTO = (ctaUserSession: CtaUserSession): CtaUserSessionDTO =>
+  pickDTOFields(ctaUserSession, ctaUserSessionDTOKeys);
+
+
+const ctaComplianceDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface CtaComplianceDTO
+  extends Pick<CtaCompliance, (typeof ctaComplianceDTOKeys)[number]> {}
+
+export const toCtaComplianceDTO = (ctaCompliance: CtaCompliance): CtaComplianceDTO =>
+  pickDTOFields(ctaCompliance, ctaComplianceDTOKeys);
+

--- a/shared/culturalEmotionTables.ts
+++ b/shared/culturalEmotionTables.ts
@@ -1,3 +1,5 @@
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 /**
  * Cultural Emotion Map Engine Database Schema
  * Enterprise-grade tables for cultural emotion mapping and personalization
@@ -227,3 +229,82 @@ export const culturalFeedback = pgTable("cultural_feedback", {
   validationStatusIdx: index("cultural_feedback_validation_status_idx").on(table.validationStatus),
   priorityIdx: index("cultural_feedback_priority_idx").on(table.priority),
 }));
+
+export type CulturalEmotionCulturalMapping = InferSelectModel<typeof culturalMappings>;
+export type InsertCulturalEmotionCulturalMapping = InferInsertModel<typeof culturalMappings>;
+export type CulturalEmotionEmotionProfile = InferSelectModel<typeof emotionProfiles>;
+export type InsertCulturalEmotionEmotionProfile = InferInsertModel<typeof emotionProfiles>;
+export type CulturalEmotionUserEmotionTracking = InferSelectModel<typeof userEmotionTracking>;
+export type InsertCulturalEmotionUserEmotionTracking = InferInsertModel<typeof userEmotionTracking>;
+export type CulturalEmotionCulturalABTest = InferSelectModel<typeof culturalABTests>;
+export type InsertCulturalEmotionCulturalABTest = InferInsertModel<typeof culturalABTests>;
+export type CulturalEmotionCulturalPersonalizationRule = InferSelectModel<typeof culturalPersonalizationRules>;
+export type InsertCulturalEmotionCulturalPersonalizationRule = InferInsertModel<typeof culturalPersonalizationRules>;
+export type CulturalEmotionCulturalAnalytic = InferSelectModel<typeof culturalAnalytics>;
+export type InsertCulturalEmotionCulturalAnalytic = InferInsertModel<typeof culturalAnalytics>;
+export type CulturalEmotionCulturalFeedback = InferSelectModel<typeof culturalFeedback>;
+export type InsertCulturalEmotionCulturalFeedback = InferInsertModel<typeof culturalFeedback>;
+
+// DTOs
+const culturalEmotionCulturalMappingDTOKeys = ["id", "region", "createdAt", "updatedAt"] as const;
+
+export interface CulturalEmotionCulturalMappingDTO
+  extends Pick<CulturalEmotionCulturalMapping, (typeof culturalEmotionCulturalMappingDTOKeys)[number]> {}
+
+export const toCulturalEmotionCulturalMappingDTO = (culturalEmotionCulturalMapping: CulturalEmotionCulturalMapping): CulturalEmotionCulturalMappingDTO =>
+  pickDTOFields(culturalEmotionCulturalMapping, culturalEmotionCulturalMappingDTOKeys);
+
+
+const culturalEmotionEmotionProfileDTOKeys = ["id", "category", "createdAt", "updatedAt"] as const;
+
+export interface CulturalEmotionEmotionProfileDTO
+  extends Pick<CulturalEmotionEmotionProfile, (typeof culturalEmotionEmotionProfileDTOKeys)[number]> {}
+
+export const toCulturalEmotionEmotionProfileDTO = (culturalEmotionEmotionProfile: CulturalEmotionEmotionProfile): CulturalEmotionEmotionProfileDTO =>
+  pickDTOFields(culturalEmotionEmotionProfile, culturalEmotionEmotionProfileDTOKeys);
+
+
+const culturalEmotionUserEmotionTrackingDTOKeys = ["id", "sessionId", "userId", "createdAt"] as const;
+
+export interface CulturalEmotionUserEmotionTrackingDTO
+  extends Pick<CulturalEmotionUserEmotionTracking, (typeof culturalEmotionUserEmotionTrackingDTOKeys)[number]> {}
+
+export const toCulturalEmotionUserEmotionTrackingDTO = (culturalEmotionUserEmotionTracking: CulturalEmotionUserEmotionTracking): CulturalEmotionUserEmotionTrackingDTO =>
+  pickDTOFields(culturalEmotionUserEmotionTracking, culturalEmotionUserEmotionTrackingDTOKeys);
+
+
+const culturalEmotionCulturalABTestDTOKeys = ["id", "status", "createdAt", "updatedAt"] as const;
+
+export interface CulturalEmotionCulturalABTestDTO
+  extends Pick<CulturalEmotionCulturalABTest, (typeof culturalEmotionCulturalABTestDTOKeys)[number]> {}
+
+export const toCulturalEmotionCulturalABTestDTO = (culturalEmotionCulturalABTest: CulturalEmotionCulturalABTest): CulturalEmotionCulturalABTestDTO =>
+  pickDTOFields(culturalEmotionCulturalABTest, culturalEmotionCulturalABTestDTOKeys);
+
+
+const culturalEmotionCulturalPersonalizationRuleDTOKeys = ["id", "ruleId", "priority", "createdAt", "updatedAt"] as const;
+
+export interface CulturalEmotionCulturalPersonalizationRuleDTO
+  extends Pick<CulturalEmotionCulturalPersonalizationRule, (typeof culturalEmotionCulturalPersonalizationRuleDTOKeys)[number]> {}
+
+export const toCulturalEmotionCulturalPersonalizationRuleDTO = (culturalEmotionCulturalPersonalizationRule: CulturalEmotionCulturalPersonalizationRule): CulturalEmotionCulturalPersonalizationRuleDTO =>
+  pickDTOFields(culturalEmotionCulturalPersonalizationRule, culturalEmotionCulturalPersonalizationRuleDTOKeys);
+
+
+const culturalEmotionCulturalAnalyticDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface CulturalEmotionCulturalAnalyticDTO
+  extends Pick<CulturalEmotionCulturalAnalytic, (typeof culturalEmotionCulturalAnalyticDTOKeys)[number]> {}
+
+export const toCulturalEmotionCulturalAnalyticDTO = (culturalEmotionCulturalAnalytic: CulturalEmotionCulturalAnalytic): CulturalEmotionCulturalAnalyticDTO =>
+  pickDTOFields(culturalEmotionCulturalAnalytic, culturalEmotionCulturalAnalyticDTOKeys);
+
+
+const culturalEmotionCulturalFeedbackDTOKeys = ["id", "priority", "createdAt", "updatedAt"] as const;
+
+export interface CulturalEmotionCulturalFeedbackDTO
+  extends Pick<CulturalEmotionCulturalFeedback, (typeof culturalEmotionCulturalFeedbackDTOKeys)[number]> {}
+
+export const toCulturalEmotionCulturalFeedbackDTO = (culturalEmotionCulturalFeedback: CulturalEmotionCulturalFeedback): CulturalEmotionCulturalFeedbackDTO =>
+  pickDTOFields(culturalEmotionCulturalFeedback, culturalEmotionCulturalFeedbackDTOKeys);
+

--- a/shared/dealSniperTables.ts
+++ b/shared/dealSniperTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // ================================================
 // GLOBAL DEAL SNIPER & PRICE TRACKER MODULE
 // Billion-Dollar Empire Grade, AI-First, Migration-Proof
@@ -321,21 +323,137 @@ export const insertPricePredictionSchema = createInsertSchema(pricePredictions);
 export const insertUserWishlistSchema = createInsertSchema(userWishlists);
 
 // Types
-export type ProductCatalog = typeof productCatalog.$inferSelect;
-export type NewProductCatalog = typeof productCatalog.$inferInsert;
-export type PriceHistory = typeof priceHistory.$inferSelect;
-export type NewPriceHistory = typeof priceHistory.$inferInsert;
-export type PriceAlert = typeof priceAlerts.$inferSelect;
-export type NewPriceAlert = typeof priceAlerts.$inferInsert;
-export type DealEvent = typeof dealEvents.$inferSelect;
-export type NewDealEvent = typeof dealEvents.$inferInsert;
-export type CouponCode = typeof couponCodes.$inferSelect;
-export type NewCouponCode = typeof couponCodes.$inferInsert;
-export type RetailerApi = typeof retailerApis.$inferSelect;
-export type NewRetailerApi = typeof retailerApis.$inferInsert;
-export type DealAnalytic = typeof dealAnalytics.$inferSelect;
-export type NewDealAnalytic = typeof dealAnalytics.$inferInsert;
-export type PricePrediction = typeof pricePredictions.$inferSelect;
-export type NewPricePrediction = typeof pricePredictions.$inferInsert;
-export type UserWishlist = typeof userWishlists.$inferSelect;
-export type NewUserWishlist = typeof userWishlists.$inferInsert;
+export type ProductCatalog = InferSelectModel<typeof productCatalog>;
+export type NewProductCatalog = InferInsertModel<typeof productCatalog>;
+export type PriceHistory = InferSelectModel<typeof priceHistory>;
+export type NewPriceHistory = InferInsertModel<typeof priceHistory>;
+export type PriceAlert = InferSelectModel<typeof priceAlerts>;
+export type NewPriceAlert = InferInsertModel<typeof priceAlerts>;
+export type DealEvent = InferSelectModel<typeof dealEvents>;
+export type NewDealEvent = InferInsertModel<typeof dealEvents>;
+export type CouponCode = InferSelectModel<typeof couponCodes>;
+export type NewCouponCode = InferInsertModel<typeof couponCodes>;
+export type RetailerApi = InferSelectModel<typeof retailerApis>;
+export type NewRetailerApi = InferInsertModel<typeof retailerApis>;
+export type DealAnalytic = InferSelectModel<typeof dealAnalytics>;
+export type NewDealAnalytic = InferInsertModel<typeof dealAnalytics>;
+export type PricePrediction = InferSelectModel<typeof pricePredictions>;
+export type NewPricePrediction = InferInsertModel<typeof pricePredictions>;
+export type UserWishlist = InferSelectModel<typeof userWishlists>;
+export type NewUserWishlist = InferInsertModel<typeof userWishlists>;
+
+export type DealCategory = InferSelectModel<typeof dealCategories>;
+export type InsertDealCategory = InferInsertModel<typeof dealCategories>;
+export type DealSource = InferSelectModel<typeof dealSources>;
+export type InsertDealSource = InferInsertModel<typeof dealSources>;
+export type DealInventory = InferSelectModel<typeof dealInventory>;
+export type InsertDealInventory = InferInsertModel<typeof dealInventory>;
+
+// DTOs
+const productCatalogDTOKeys = ["id", "category", "createdAt", "updatedAt", "description"] as const;
+
+export interface ProductCatalogDTO
+  extends Pick<ProductCatalog, (typeof productCatalogDTOKeys)[number]> {}
+
+export const toProductCatalogDTO = (productCatalog: ProductCatalog): ProductCatalogDTO =>
+  pickDTOFields(productCatalog, productCatalogDTOKeys);
+
+
+const priceHistoryDTOKeys = ["id", "createdAt", "productId"] as const;
+
+export interface PriceHistoryDTO
+  extends Pick<PriceHistory, (typeof priceHistoryDTOKeys)[number]> {}
+
+export const toPriceHistoryDTO = (priceHistory: PriceHistory): PriceHistoryDTO =>
+  pickDTOFields(priceHistory, priceHistoryDTOKeys);
+
+
+const priceAlertDTOKeys = ["id", "userId", "createdAt", "updatedAt", "productId"] as const;
+
+export interface PriceAlertDTO
+  extends Pick<PriceAlert, (typeof priceAlertDTOKeys)[number]> {}
+
+export const toPriceAlertDTO = (priceAlert: PriceAlert): PriceAlertDTO =>
+  pickDTOFields(priceAlert, priceAlertDTOKeys);
+
+
+const dealEventDTOKeys = ["id", "createdAt", "productId"] as const;
+
+export interface DealEventDTO
+  extends Pick<DealEvent, (typeof dealEventDTOKeys)[number]> {}
+
+export const toDealEventDTO = (dealEvent: DealEvent): DealEventDTO =>
+  pickDTOFields(dealEvent, dealEventDTOKeys);
+
+
+const couponCodeDTOKeys = ["id", "createdAt", "updatedAt", "description", "source"] as const;
+
+export interface CouponCodeDTO
+  extends Pick<CouponCode, (typeof couponCodeDTOKeys)[number]> {}
+
+export const toCouponCodeDTO = (couponCode: CouponCode): CouponCodeDTO =>
+  pickDTOFields(couponCode, couponCodeDTOKeys);
+
+
+const retailerApiDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface RetailerApiDTO
+  extends Pick<RetailerApi, (typeof retailerApiDTOKeys)[number]> {}
+
+export const toRetailerApiDTO = (retailerApi: RetailerApi): RetailerApiDTO =>
+  pickDTOFields(retailerApi, retailerApiDTOKeys);
+
+
+const dealAnalyticDTOKeys = ["id", "userId", "createdAt", "eventType", "productId"] as const;
+
+export interface DealAnalyticDTO
+  extends Pick<DealAnalytic, (typeof dealAnalyticDTOKeys)[number]> {}
+
+export const toDealAnalyticDTO = (dealAnalytic: DealAnalytic): DealAnalyticDTO =>
+  pickDTOFields(dealAnalytic, dealAnalyticDTOKeys);
+
+
+const pricePredictionDTOKeys = ["id", "createdAt", "productId"] as const;
+
+export interface PricePredictionDTO
+  extends Pick<PricePrediction, (typeof pricePredictionDTOKeys)[number]> {}
+
+export const toPricePredictionDTO = (pricePrediction: PricePrediction): PricePredictionDTO =>
+  pickDTOFields(pricePrediction, pricePredictionDTOKeys);
+
+
+const userWishlistDTOKeys = ["id", "userId", "priority", "createdAt", "updatedAt", "productId"] as const;
+
+export interface UserWishlistDTO
+  extends Pick<UserWishlist, (typeof userWishlistDTOKeys)[number]> {}
+
+export const toUserWishlistDTO = (userWishlist: UserWishlist): UserWishlistDTO =>
+  pickDTOFields(userWishlist, userWishlistDTOKeys);
+
+
+const dealCategoryDTOKeys = ["id", "priority", "createdAt", "updatedAt", "description"] as const;
+
+export interface DealCategoryDTO
+  extends Pick<DealCategory, (typeof dealCategoryDTOKeys)[number]> {}
+
+export const toDealCategoryDTO = (dealCategory: DealCategory): DealCategoryDTO =>
+  pickDTOFields(dealCategory, dealCategoryDTOKeys);
+
+
+const dealSourceDTOKeys = ["id", "priority", "createdAt", "updatedAt"] as const;
+
+export interface DealSourceDTO
+  extends Pick<DealSource, (typeof dealSourceDTOKeys)[number]> {}
+
+export const toDealSourceDTO = (dealSource: DealSource): DealSourceDTO =>
+  pickDTOFields(dealSource, dealSourceDTOKeys);
+
+
+const dealInventoryDTOKeys = ["id", "category", "createdAt", "updatedAt"] as const;
+
+export interface DealInventoryDTO
+  extends Pick<DealInventory, (typeof dealInventoryDTOKeys)[number]> {}
+
+export const toDealInventoryDTO = (dealInventory: DealInventory): DealInventoryDTO =>
+  pickDTOFields(dealInventory, dealInventoryDTOKeys);
+

--- a/shared/deploymentTables.ts
+++ b/shared/deploymentTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // ==========================================
 // EXPORT/IMPORT BOOSTER SYSTEM TABLES
 // ==========================================
@@ -215,21 +217,103 @@ export const insertDeploymentPermissionSchema = createInsertSchema(deploymentPer
 export const insertMultiRegionConfigSchema = createInsertSchema(multiRegionConfig);
 
 // Export type definitions
-export type ExportArchive = typeof exportArchives.$inferSelect;
-export type NewExportArchive = typeof exportArchives.$inferInsert;
-export type ImportOperation = typeof importOperations.$inferSelect;
-export type NewImportOperation = typeof importOperations.$inferInsert;
-export type Deployment = typeof deployments.$inferSelect;
-export type NewDeployment = typeof deployments.$inferInsert;
-export type DeploymentStep = typeof deploymentSteps.$inferSelect;
-export type NewDeploymentStep = typeof deploymentSteps.$inferInsert;
-export type Backup = typeof backups.$inferSelect;
-export type NewBackup = typeof backups.$inferInsert;
-export type DisasterRecoveryPlan = typeof disasterRecoveryPlans.$inferSelect;
-export type NewDisasterRecoveryPlan = typeof disasterRecoveryPlans.$inferInsert;
-export type DeploymentAudit = typeof deploymentAudit.$inferSelect;
-export type NewDeploymentAudit = typeof deploymentAudit.$inferInsert;
-export type DeploymentPermission = typeof deploymentPermissions.$inferSelect;
-export type NewDeploymentPermission = typeof deploymentPermissions.$inferInsert;
-export type MultiRegionConfig = typeof multiRegionConfig.$inferSelect;
-export type NewMultiRegionConfig = typeof multiRegionConfig.$inferInsert;
+export type ExportArchive = InferSelectModel<typeof exportArchives>;
+export type NewExportArchive = InferInsertModel<typeof exportArchives>;
+export type ImportOperation = InferSelectModel<typeof importOperations>;
+export type NewImportOperation = InferInsertModel<typeof importOperations>;
+export type Deployment = InferSelectModel<typeof deployments>;
+export type NewDeployment = InferInsertModel<typeof deployments>;
+export type DeploymentStep = InferSelectModel<typeof deploymentSteps>;
+export type NewDeploymentStep = InferInsertModel<typeof deploymentSteps>;
+export type Backup = InferSelectModel<typeof backups>;
+export type NewBackup = InferInsertModel<typeof backups>;
+export type DisasterRecoveryPlan = InferSelectModel<typeof disasterRecoveryPlans>;
+export type NewDisasterRecoveryPlan = InferInsertModel<typeof disasterRecoveryPlans>;
+export type DeploymentAudit = InferSelectModel<typeof deploymentAudit>;
+export type NewDeploymentAudit = InferInsertModel<typeof deploymentAudit>;
+export type DeploymentPermission = InferSelectModel<typeof deploymentPermissions>;
+export type NewDeploymentPermission = InferInsertModel<typeof deploymentPermissions>;
+export type MultiRegionConfig = InferSelectModel<typeof multiRegionConfig>;
+export type NewMultiRegionConfig = InferInsertModel<typeof multiRegionConfig>;
+
+// DTOs
+const exportArchiveDTOKeys = ["id", "name", "status", "createdAt", "description", "version"] as const;
+
+export interface ExportArchiveDTO
+  extends Pick<ExportArchive, (typeof exportArchiveDTOKeys)[number]> {}
+
+export const toExportArchiveDTO = (exportArchive: ExportArchive): ExportArchiveDTO =>
+  pickDTOFields(exportArchive, exportArchiveDTOKeys);
+
+
+const importOperationDTOKeys = ["id", "name", "status", "createdAt"] as const;
+
+export interface ImportOperationDTO
+  extends Pick<ImportOperation, (typeof importOperationDTOKeys)[number]> {}
+
+export const toImportOperationDTO = (importOperation: ImportOperation): ImportOperationDTO =>
+  pickDTOFields(importOperation, importOperationDTOKeys);
+
+
+const deploymentDTOKeys = ["id", "name", "status", "createdAt", "version", "environment"] as const;
+
+export interface DeploymentDTO
+  extends Pick<Deployment, (typeof deploymentDTOKeys)[number]> {}
+
+export const toDeploymentDTO = (deployment: Deployment): DeploymentDTO =>
+  pickDTOFields(deployment, deploymentDTOKeys);
+
+
+const deploymentStepDTOKeys = ["id", "name", "status", "createdAt", "description"] as const;
+
+export interface DeploymentStepDTO
+  extends Pick<DeploymentStep, (typeof deploymentStepDTOKeys)[number]> {}
+
+export const toDeploymentStepDTO = (deploymentStep: DeploymentStep): DeploymentStepDTO =>
+  pickDTOFields(deploymentStep, deploymentStepDTOKeys);
+
+
+const backupDTOKeys = ["id", "name", "status", "createdAt"] as const;
+
+export interface BackupDTO
+  extends Pick<Backup, (typeof backupDTOKeys)[number]> {}
+
+export const toBackupDTO = (backup: Backup): BackupDTO =>
+  pickDTOFields(backup, backupDTOKeys);
+
+
+const disasterRecoveryPlanDTOKeys = ["id", "name", "planId", "priority", "createdAt", "updatedAt", "description"] as const;
+
+export interface DisasterRecoveryPlanDTO
+  extends Pick<DisasterRecoveryPlan, (typeof disasterRecoveryPlanDTOKeys)[number]> {}
+
+export const toDisasterRecoveryPlanDTO = (disasterRecoveryPlan: DisasterRecoveryPlan): DisasterRecoveryPlanDTO =>
+  pickDTOFields(disasterRecoveryPlan, disasterRecoveryPlanDTOKeys);
+
+
+const deploymentAuditDTOKeys = ["id", "userId", "createdAt"] as const;
+
+export interface DeploymentAuditDTO
+  extends Pick<DeploymentAudit, (typeof deploymentAuditDTOKeys)[number]> {}
+
+export const toDeploymentAuditDTO = (deploymentAudit: DeploymentAudit): DeploymentAuditDTO =>
+  pickDTOFields(deploymentAudit, deploymentAuditDTOKeys);
+
+
+const deploymentPermissionDTOKeys = ["id", "userId", "createdAt", "updatedAt", "role"] as const;
+
+export interface DeploymentPermissionDTO
+  extends Pick<DeploymentPermission, (typeof deploymentPermissionDTOKeys)[number]> {}
+
+export const toDeploymentPermissionDTO = (deploymentPermission: DeploymentPermission): DeploymentPermissionDTO =>
+  pickDTOFields(deploymentPermission, deploymentPermissionDTOKeys);
+
+
+const multiRegionConfigDTOKeys = ["id", "name", "createdAt", "updatedAt"] as const;
+
+export interface MultiRegionConfigDTO
+  extends Pick<MultiRegionConfig, (typeof multiRegionConfigDTOKeys)[number]> {}
+
+export const toMultiRegionConfigDTO = (multiRegionConfig: MultiRegionConfig): MultiRegionConfigDTO =>
+  pickDTOFields(multiRegionConfig, multiRegionConfigDTOKeys);
+

--- a/shared/disasterRecoveryTables.ts
+++ b/shared/disasterRecoveryTables.ts
@@ -1,3 +1,5 @@
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 /**
  * Disaster Recovery Database Schema
  * Enterprise-grade tables for comprehensive disaster recovery management
@@ -23,3 +25,16 @@ export const disasterRecoveryScenarios = pgTable('disaster_recovery_scenarios', 
   created_at: timestamp('created_at').defaultNow().notNull(),
   updated_at: timestamp('updated_at').defaultNow().notNull()
 });
+
+export type DisasterRecoveryDisasterRecoveryScenario = InferSelectModel<typeof disasterRecoveryScenarios>;
+export type InsertDisasterRecoveryDisasterRecoveryScenario = InferInsertModel<typeof disasterRecoveryScenarios>;
+
+// DTOs
+const disasterRecoveryDisasterRecoveryScenarioDTOKeys = ["id", "scenario_name", "scenario_type"] as const;
+
+export interface DisasterRecoveryDisasterRecoveryScenarioDTO
+  extends Pick<DisasterRecoveryDisasterRecoveryScenario, (typeof disasterRecoveryDisasterRecoveryScenarioDTOKeys)[number]> {}
+
+export const toDisasterRecoveryDisasterRecoveryScenarioDTO = (disasterRecoveryDisasterRecoveryScenario: DisasterRecoveryDisasterRecoveryScenario): DisasterRecoveryDisasterRecoveryScenarioDTO =>
+  pickDTOFields(disasterRecoveryDisasterRecoveryScenario, disasterRecoveryDisasterRecoveryScenarioDTOKeys);
+

--- a/shared/dtoHelpers.ts
+++ b/shared/dtoHelpers.ts
@@ -1,0 +1,10 @@
+export const pickDTOFields = <T extends Record<string, unknown>, K extends keyof T>(
+  record: T,
+  keys: readonly K[],
+): Pick<T, K> => {
+  const result: Partial<Pick<T, K>> = {};
+  for (const key of keys) {
+    result[key] = record[key];
+  }
+  return result as Pick<T, K>;
+};

--- a/shared/educationTables.ts
+++ b/shared/educationTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // Education User Archetypes (Students, Career Switchers, Hobbyists)
 export const educationArchetypes = pgTable("education_archetypes", {
   id: serial("id").primaryKey(),
@@ -352,14 +354,147 @@ export const insertEducationOfferSchema = createInsertSchema(educationOffers).pi
 });
 
 // Type exports
-export type InsertEducationArchetype = z.infer<typeof insertEducationArchetypeSchema>;
-export type InsertEducationContent = z.infer<typeof insertEducationContentSchema>;
-export type InsertEducationQuiz = z.infer<typeof insertEducationQuizSchema>;
-export type InsertEducationOffer = z.infer<typeof insertEducationOfferSchema>;
+export type InsertEducationArchetype = InferInsertModel<typeof educationArchetypes>;
+export type InsertEducationContent = InferInsertModel<typeof educationContent>;
+export type InsertEducationQuiz = InferInsertModel<typeof educationQuizzes>;
+export type InsertEducationOffer = InferInsertModel<typeof educationOffers>;
 
-export type EducationArchetype = typeof educationArchetypes.$inferSelect;
-export type EducationContent = typeof educationContent.$inferSelect;
-export type EducationQuiz = typeof educationQuizzes.$inferSelect;
-export type EducationOffer = typeof educationOffers.$inferSelect;
-export type EducationProgress = typeof educationProgress.$inferSelect;
-export type EducationGamification = typeof educationGamification.$inferSelect;
+export type EducationArchetype = InferSelectModel<typeof educationArchetypes>;
+export type EducationContent = InferSelectModel<typeof educationContent>;
+export type EducationQuiz = InferSelectModel<typeof educationQuizzes>;
+export type EducationOffer = InferSelectModel<typeof educationOffers>;
+export type EducationProgress = InferSelectModel<typeof educationProgress>;
+export type EducationGamification = InferSelectModel<typeof educationGamification>;
+
+export type EducationQuizResult = InferSelectModel<typeof educationQuizResults>;
+export type InsertEducationQuizResult = InferInsertModel<typeof educationQuizResults>;
+export type EducationPath = InferSelectModel<typeof educationPaths>;
+export type InsertEducationPath = InferInsertModel<typeof educationPaths>;
+export type EducationTool = InferSelectModel<typeof educationTools>;
+export type InsertEducationTool = InferInsertModel<typeof educationTools>;
+export type EducationToolSession = InferSelectModel<typeof educationToolSessions>;
+export type InsertEducationToolSession = InferInsertModel<typeof educationToolSessions>;
+export type EducationAIChatSession = InferSelectModel<typeof educationAIChatSessions>;
+export type InsertEducationAIChatSession = InferInsertModel<typeof educationAIChatSessions>;
+export type EducationDailyQuest = InferSelectModel<typeof educationDailyQuests>;
+export type InsertEducationDailyQuest = InferInsertModel<typeof educationDailyQuests>;
+export type EducationQuestCompletion = InferSelectModel<typeof educationQuestCompletions>;
+export type InsertEducationQuestCompletion = InferInsertModel<typeof educationQuestCompletions>;
+
+// DTOs
+const educationArchetypeDTOKeys = ["id", "name", "slug", "createdAt", "updatedAt", "description"] as const;
+
+export interface EducationArchetypeDTO
+  extends Pick<EducationArchetype, (typeof educationArchetypeDTOKeys)[number]> {}
+
+export const toEducationArchetypeDTO = (educationArchetype: EducationArchetype): EducationArchetypeDTO =>
+  pickDTOFields(educationArchetype, educationArchetypeDTOKeys);
+
+
+const educationContentDTOKeys = ["id", "title", "slug", "category", "createdAt", "updatedAt"] as const;
+
+export interface EducationContentDTO
+  extends Pick<EducationContent, (typeof educationContentDTOKeys)[number]> {}
+
+export const toEducationContentDTO = (educationContent: EducationContent): EducationContentDTO =>
+  pickDTOFields(educationContent, educationContentDTOKeys);
+
+
+const educationQuizDTOKeys = ["id", "title", "slug", "category", "createdAt", "updatedAt", "description", "quizType"] as const;
+
+export interface EducationQuizDTO
+  extends Pick<EducationQuiz, (typeof educationQuizDTOKeys)[number]> {}
+
+export const toEducationQuizDTO = (educationQuiz: EducationQuiz): EducationQuizDTO =>
+  pickDTOFields(educationQuiz, educationQuizDTOKeys);
+
+
+const educationOfferDTOKeys = ["id", "title", "slug", "category", "createdAt", "updatedAt", "description", "provider"] as const;
+
+export interface EducationOfferDTO
+  extends Pick<EducationOffer, (typeof educationOfferDTOKeys)[number]> {}
+
+export const toEducationOfferDTO = (educationOffer: EducationOffer): EducationOfferDTO =>
+  pickDTOFields(educationOffer, educationOfferDTOKeys);
+
+
+const educationProgressDTOKeys = ["id", "status", "sessionId", "userId", "createdAt", "updatedAt"] as const;
+
+export interface EducationProgressDTO
+  extends Pick<EducationProgress, (typeof educationProgressDTOKeys)[number]> {}
+
+export const toEducationProgressDTO = (educationProgress: EducationProgress): EducationProgressDTO =>
+  pickDTOFields(educationProgress, educationProgressDTOKeys);
+
+
+const educationGamificationDTOKeys = ["id", "sessionId", "userId", "level", "createdAt", "updatedAt"] as const;
+
+export interface EducationGamificationDTO
+  extends Pick<EducationGamification, (typeof educationGamificationDTOKeys)[number]> {}
+
+export const toEducationGamificationDTO = (educationGamification: EducationGamification): EducationGamificationDTO =>
+  pickDTOFields(educationGamification, educationGamificationDTOKeys);
+
+
+const educationQuizResultDTOKeys = ["id", "sessionId", "userId", "createdAt"] as const;
+
+export interface EducationQuizResultDTO
+  extends Pick<EducationQuizResult, (typeof educationQuizResultDTOKeys)[number]> {}
+
+export const toEducationQuizResultDTO = (educationQuizResult: EducationQuizResult): EducationQuizResultDTO =>
+  pickDTOFields(educationQuizResult, educationQuizResultDTOKeys);
+
+
+const educationPathDTOKeys = ["id", "title", "slug", "category", "createdAt", "updatedAt", "description"] as const;
+
+export interface EducationPathDTO
+  extends Pick<EducationPath, (typeof educationPathDTOKeys)[number]> {}
+
+export const toEducationPathDTO = (educationPath: EducationPath): EducationPathDTO =>
+  pickDTOFields(educationPath, educationPathDTOKeys);
+
+
+const educationToolDTOKeys = ["id", "name", "slug", "category", "createdAt", "updatedAt", "description"] as const;
+
+export interface EducationToolDTO
+  extends Pick<EducationTool, (typeof educationToolDTOKeys)[number]> {}
+
+export const toEducationToolDTO = (educationTool: EducationTool): EducationToolDTO =>
+  pickDTOFields(educationTool, educationToolDTOKeys);
+
+
+const educationToolSessionDTOKeys = ["id", "sessionId", "userId", "createdAt", "toolId"] as const;
+
+export interface EducationToolSessionDTO
+  extends Pick<EducationToolSession, (typeof educationToolSessionDTOKeys)[number]> {}
+
+export const toEducationToolSessionDTO = (educationToolSession: EducationToolSession): EducationToolSessionDTO =>
+  pickDTOFields(educationToolSession, educationToolSessionDTOKeys);
+
+
+const educationAIChatSessionDTOKeys = ["id", "sessionId", "userId", "createdAt", "updatedAt"] as const;
+
+export interface EducationAIChatSessionDTO
+  extends Pick<EducationAIChatSession, (typeof educationAIChatSessionDTOKeys)[number]> {}
+
+export const toEducationAIChatSessionDTO = (educationAIChatSession: EducationAIChatSession): EducationAIChatSessionDTO =>
+  pickDTOFields(educationAIChatSession, educationAIChatSessionDTOKeys);
+
+
+const educationDailyQuestDTOKeys = ["id", "title", "category", "createdAt", "description"] as const;
+
+export interface EducationDailyQuestDTO
+  extends Pick<EducationDailyQuest, (typeof educationDailyQuestDTOKeys)[number]> {}
+
+export const toEducationDailyQuestDTO = (educationDailyQuest: EducationDailyQuest): EducationDailyQuestDTO =>
+  pickDTOFields(educationDailyQuest, educationDailyQuestDTOKeys);
+
+
+const educationQuestCompletionDTOKeys = ["id", "sessionId", "userId", "createdAt"] as const;
+
+export interface EducationQuestCompletionDTO
+  extends Pick<EducationQuestCompletion, (typeof educationQuestCompletionDTOKeys)[number]> {}
+
+export const toEducationQuestCompletionDTO = (educationQuestCompletion: EducationQuestCompletion): EducationQuestCompletionDTO =>
+  pickDTOFields(educationQuestCompletion, educationQuestCompletionDTOKeys);
+

--- a/shared/empireBrainTables.ts
+++ b/shared/empireBrainTables.ts
@@ -1,3 +1,5 @@
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 /**
  * Empire Brain "Throne Protocol" Database Tables
  * Billion-Dollar Empire Grade, Migration-Proof, Auto-Healing Schema
@@ -308,3 +310,115 @@ export type NewEmpireVectorMemory = z.infer<typeof createEmpireVectorMemorySchem
 export type NewIntentGraph = z.infer<typeof createIntentGraphSchema>;
 export type NewEmpireBrainConfig = z.infer<typeof createEmpireBrainConfigSchema>;
 export type NewEmpireAnalytics = z.infer<typeof createEmpireAnalyticsSchema>;
+
+export type EmpireBrainEmpireIntelligence = InferSelectModel<typeof empireIntelligence>;
+export type InsertEmpireBrainEmpireIntelligence = InferInsertModel<typeof empireIntelligence>;
+export type EmpireBrainLlmProvider = InferSelectModel<typeof llmProviders>;
+export type InsertEmpireBrainLlmProvider = InferInsertModel<typeof llmProviders>;
+export type EmpireBrainIntelligenceRoute = InferSelectModel<typeof intelligenceRoutes>;
+export type InsertEmpireBrainIntelligenceRoute = InferInsertModel<typeof intelligenceRoutes>;
+export type EmpireBrainAutonomicDecision = InferSelectModel<typeof autonomicDecisions>;
+export type InsertEmpireBrainAutonomicDecision = InferInsertModel<typeof autonomicDecisions>;
+export type EmpireBrainSystemMutation = InferSelectModel<typeof systemMutations>;
+export type InsertEmpireBrainSystemMutation = InferInsertModel<typeof systemMutations>;
+export type EmpireBrainRlhfFeedback = InferSelectModel<typeof rlhfFeedback>;
+export type InsertEmpireBrainRlhfFeedback = InferInsertModel<typeof rlhfFeedback>;
+export type EmpireBrainEmpireVectorMemory = InferSelectModel<typeof empireVectorMemory>;
+export type InsertEmpireBrainEmpireVectorMemory = InferInsertModel<typeof empireVectorMemory>;
+export type EmpireBrainIntentGraph = InferSelectModel<typeof intentGraphs>;
+export type InsertEmpireBrainIntentGraph = InferInsertModel<typeof intentGraphs>;
+export type EmpireBrainEmpireBrainConfig = InferSelectModel<typeof empireBrainConfig>;
+export type InsertEmpireBrainEmpireBrainConfig = InferInsertModel<typeof empireBrainConfig>;
+export type EmpireBrainEmpireAnalytic = InferSelectModel<typeof empireAnalytics>;
+export type InsertEmpireBrainEmpireAnalytic = InferInsertModel<typeof empireAnalytics>;
+
+// DTOs
+const empireBrainEmpireIntelligenceDTOKeys = ["id", "status", "priority", "createdAt", "updatedAt"] as const;
+
+export interface EmpireBrainEmpireIntelligenceDTO
+  extends Pick<EmpireBrainEmpireIntelligence, (typeof empireBrainEmpireIntelligenceDTOKeys)[number]> {}
+
+export const toEmpireBrainEmpireIntelligenceDTO = (empireBrainEmpireIntelligence: EmpireBrainEmpireIntelligence): EmpireBrainEmpireIntelligenceDTO =>
+  pickDTOFields(empireBrainEmpireIntelligence, empireBrainEmpireIntelligenceDTOKeys);
+
+
+const empireBrainLlmProviderDTOKeys = ["id", "priority", "createdAt", "updatedAt"] as const;
+
+export interface EmpireBrainLlmProviderDTO
+  extends Pick<EmpireBrainLlmProvider, (typeof empireBrainLlmProviderDTOKeys)[number]> {}
+
+export const toEmpireBrainLlmProviderDTO = (empireBrainLlmProvider: EmpireBrainLlmProvider): EmpireBrainLlmProviderDTO =>
+  pickDTOFields(empireBrainLlmProvider, empireBrainLlmProviderDTOKeys);
+
+
+const empireBrainIntelligenceRouteDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface EmpireBrainIntelligenceRouteDTO
+  extends Pick<EmpireBrainIntelligenceRoute, (typeof empireBrainIntelligenceRouteDTOKeys)[number]> {}
+
+export const toEmpireBrainIntelligenceRouteDTO = (empireBrainIntelligenceRoute: EmpireBrainIntelligenceRoute): EmpireBrainIntelligenceRouteDTO =>
+  pickDTOFields(empireBrainIntelligenceRoute, empireBrainIntelligenceRouteDTOKeys);
+
+
+const empireBrainAutonomicDecisionDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface EmpireBrainAutonomicDecisionDTO
+  extends Pick<EmpireBrainAutonomicDecision, (typeof empireBrainAutonomicDecisionDTOKeys)[number]> {}
+
+export const toEmpireBrainAutonomicDecisionDTO = (empireBrainAutonomicDecision: EmpireBrainAutonomicDecision): EmpireBrainAutonomicDecisionDTO =>
+  pickDTOFields(empireBrainAutonomicDecision, empireBrainAutonomicDecisionDTOKeys);
+
+
+const empireBrainSystemMutationDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface EmpireBrainSystemMutationDTO
+  extends Pick<EmpireBrainSystemMutation, (typeof empireBrainSystemMutationDTOKeys)[number]> {}
+
+export const toEmpireBrainSystemMutationDTO = (empireBrainSystemMutation: EmpireBrainSystemMutation): EmpireBrainSystemMutationDTO =>
+  pickDTOFields(empireBrainSystemMutation, empireBrainSystemMutationDTOKeys);
+
+
+const empireBrainRlhfFeedbackDTOKeys = ["id", "sessionId", "userId", "createdAt", "updatedAt"] as const;
+
+export interface EmpireBrainRlhfFeedbackDTO
+  extends Pick<EmpireBrainRlhfFeedback, (typeof empireBrainRlhfFeedbackDTOKeys)[number]> {}
+
+export const toEmpireBrainRlhfFeedbackDTO = (empireBrainRlhfFeedback: EmpireBrainRlhfFeedback): EmpireBrainRlhfFeedbackDTO =>
+  pickDTOFields(empireBrainRlhfFeedback, empireBrainRlhfFeedbackDTOKeys);
+
+
+const empireBrainEmpireVectorMemoryDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface EmpireBrainEmpireVectorMemoryDTO
+  extends Pick<EmpireBrainEmpireVectorMemory, (typeof empireBrainEmpireVectorMemoryDTOKeys)[number]> {}
+
+export const toEmpireBrainEmpireVectorMemoryDTO = (empireBrainEmpireVectorMemory: EmpireBrainEmpireVectorMemory): EmpireBrainEmpireVectorMemoryDTO =>
+  pickDTOFields(empireBrainEmpireVectorMemory, empireBrainEmpireVectorMemoryDTOKeys);
+
+
+const empireBrainIntentGraphDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface EmpireBrainIntentGraphDTO
+  extends Pick<EmpireBrainIntentGraph, (typeof empireBrainIntentGraphDTOKeys)[number]> {}
+
+export const toEmpireBrainIntentGraphDTO = (empireBrainIntentGraph: EmpireBrainIntentGraph): EmpireBrainIntentGraphDTO =>
+  pickDTOFields(empireBrainIntentGraph, empireBrainIntentGraphDTOKeys);
+
+
+const empireBrainEmpireBrainConfigDTOKeys = ["id", "createdAt", "updatedAt", "description"] as const;
+
+export interface EmpireBrainEmpireBrainConfigDTO
+  extends Pick<EmpireBrainEmpireBrainConfig, (typeof empireBrainEmpireBrainConfigDTOKeys)[number]> {}
+
+export const toEmpireBrainEmpireBrainConfigDTO = (empireBrainEmpireBrainConfig: EmpireBrainEmpireBrainConfig): EmpireBrainEmpireBrainConfigDTO =>
+  pickDTOFields(empireBrainEmpireBrainConfig, empireBrainEmpireBrainConfigDTOKeys);
+
+
+const empireBrainEmpireAnalyticDTOKeys = ["id", "createdAt", "metricName"] as const;
+
+export interface EmpireBrainEmpireAnalyticDTO
+  extends Pick<EmpireBrainEmpireAnalytic, (typeof empireBrainEmpireAnalyticDTOKeys)[number]> {}
+
+export const toEmpireBrainEmpireAnalyticDTO = (empireBrainEmpireAnalytic: EmpireBrainEmpireAnalytic): EmpireBrainEmpireAnalyticDTO =>
+  pickDTOFields(empireBrainEmpireAnalytic, empireBrainEmpireAnalyticDTOKeys);
+

--- a/shared/empireSecurityTables.ts
+++ b/shared/empireSecurityTables.ts
@@ -1,3 +1,5 @@
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 /**
  * EMPIRE-GRADE SECURITY TABLES
  * Billion-Dollar Migration-Proof JWT Auth + API Key Vault + CDN Cache + LLM Fallback
@@ -255,23 +257,114 @@ export const insertLlmUsageAnalyticsSchema = createInsertSchema(llmUsageAnalytic
 export const insertMigrationEventsSchema = createInsertSchema(migrationEvents);
 
 // Export types
-export type SecretsVault = typeof secretsVault.$inferSelect;
-export type InsertSecretsVault = z.infer<typeof insertSecretsVaultSchema>;
-export type SecretRotationHistory = typeof secretRotationHistory.$inferSelect;
-export type InsertSecretRotationHistory = z.infer<typeof insertSecretRotationHistorySchema>;
-export type ApiAccessTokens = typeof apiAccessTokens.$inferSelect;
-export type InsertApiAccessTokens = z.infer<typeof insertApiAccessTokensSchema>;
-export type CdnCacheConfig = typeof cdnCacheConfig.$inferSelect;
-export type InsertCdnCacheConfig = z.infer<typeof insertCdnCacheConfigSchema>;
-export type CacheInvalidationLogs = typeof cacheInvalidationLogs.$inferSelect;
-export type InsertCacheInvalidationLogs = z.infer<typeof insertCacheInvalidationLogsSchema>;
-export type CachePerformanceMetrics = typeof cachePerformanceMetrics.$inferSelect;
-export type InsertCachePerformanceMetrics = z.infer<typeof insertCachePerformanceMetricsSchema>;
-export type LlmFallbacks = typeof llmFallbacks.$inferSelect;
-export type InsertLlmFallbacks = z.infer<typeof insertLlmFallbacksSchema>;
-export type LlmFallbackEvents = typeof llmFallbackEvents.$inferSelect;
-export type InsertLlmFallbackEvents = z.infer<typeof insertLlmFallbackEventsSchema>;
-export type LlmUsageAnalytics = typeof llmUsageAnalytics.$inferSelect;
-export type InsertLlmUsageAnalytics = z.infer<typeof insertLlmUsageAnalyticsSchema>;
-export type MigrationEvents = typeof migrationEvents.$inferSelect;
-export type InsertMigrationEvents = z.infer<typeof insertMigrationEventsSchema>;
+export type SecretsVault = InferSelectModel<typeof secretsVault>;
+export type InsertSecretsVault = InferInsertModel<typeof secretsVault>;
+export type SecretRotationHistory = InferSelectModel<typeof secretRotationHistory>;
+export type InsertSecretRotationHistory = InferInsertModel<typeof secretRotationHistory>;
+export type ApiAccessTokens = InferSelectModel<typeof apiAccessTokens>;
+export type InsertApiAccessTokens = InferInsertModel<typeof apiAccessTokens>;
+export type CdnCacheConfig = InferSelectModel<typeof cdnCacheConfig>;
+export type InsertCdnCacheConfig = InferInsertModel<typeof cdnCacheConfig>;
+export type CacheInvalidationLogs = InferSelectModel<typeof cacheInvalidationLogs>;
+export type InsertCacheInvalidationLogs = InferInsertModel<typeof cacheInvalidationLogs>;
+export type CachePerformanceMetrics = InferSelectModel<typeof cachePerformanceMetrics>;
+export type InsertCachePerformanceMetrics = InferInsertModel<typeof cachePerformanceMetrics>;
+export type LlmFallbacks = InferSelectModel<typeof llmFallbacks>;
+export type InsertLlmFallbacks = InferInsertModel<typeof llmFallbacks>;
+export type LlmFallbackEvents = InferSelectModel<typeof llmFallbackEvents>;
+export type InsertLlmFallbackEvents = InferInsertModel<typeof llmFallbackEvents>;
+export type LlmUsageAnalytics = InferSelectModel<typeof llmUsageAnalytics>;
+export type InsertLlmUsageAnalytics = InferInsertModel<typeof llmUsageAnalytics>;
+export type MigrationEvents = InferSelectModel<typeof migrationEvents>;
+export type InsertMigrationEvents = InferInsertModel<typeof migrationEvents>;
+
+// DTOs
+const secretsVaultDTOKeys = ["id", "createdAt", "updatedAt", "description", "version", "environment"] as const;
+
+export interface SecretsVaultDTO
+  extends Pick<SecretsVault, (typeof secretsVaultDTOKeys)[number]> {}
+
+export const toSecretsVaultDTO = (secretsVault: SecretsVault): SecretsVaultDTO =>
+  pickDTOFields(secretsVault, secretsVaultDTOKeys);
+
+
+const secretRotationHistoryDTOKeys = ["id", "keyId", "oldValue"] as const;
+
+export interface SecretRotationHistoryDTO
+  extends Pick<SecretRotationHistory, (typeof secretRotationHistoryDTOKeys)[number]> {}
+
+export const toSecretRotationHistoryDTO = (secretRotationHistory: SecretRotationHistory): SecretRotationHistoryDTO =>
+  pickDTOFields(secretRotationHistory, secretRotationHistoryDTOKeys);
+
+
+const apiAccessTokensDTOKeys = ["id", "userId", "createdAt", "updatedAt"] as const;
+
+export interface ApiAccessTokensDTO
+  extends Pick<ApiAccessTokens, (typeof apiAccessTokensDTOKeys)[number]> {}
+
+export const toApiAccessTokensDTO = (apiAccessTokens: ApiAccessTokens): ApiAccessTokensDTO =>
+  pickDTOFields(apiAccessTokens, apiAccessTokensDTOKeys);
+
+
+const cdnCacheConfigDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface CdnCacheConfigDTO
+  extends Pick<CdnCacheConfig, (typeof cdnCacheConfigDTOKeys)[number]> {}
+
+export const toCdnCacheConfigDTO = (cdnCacheConfig: CdnCacheConfig): CdnCacheConfigDTO =>
+  pickDTOFields(cdnCacheConfig, cdnCacheConfigDTOKeys);
+
+
+const cacheInvalidationLogsDTOKeys = ["id", "routeId", "invalidationType"] as const;
+
+export interface CacheInvalidationLogsDTO
+  extends Pick<CacheInvalidationLogs, (typeof cacheInvalidationLogsDTOKeys)[number]> {}
+
+export const toCacheInvalidationLogsDTO = (cacheInvalidationLogs: CacheInvalidationLogs): CacheInvalidationLogsDTO =>
+  pickDTOFields(cacheInvalidationLogs, cacheInvalidationLogsDTOKeys);
+
+
+const cachePerformanceMetricsDTOKeys = ["id", "createdAt", "routeId"] as const;
+
+export interface CachePerformanceMetricsDTO
+  extends Pick<CachePerformanceMetrics, (typeof cachePerformanceMetricsDTOKeys)[number]> {}
+
+export const toCachePerformanceMetricsDTO = (cachePerformanceMetrics: CachePerformanceMetrics): CachePerformanceMetricsDTO =>
+  pickDTOFields(cachePerformanceMetrics, cachePerformanceMetricsDTOKeys);
+
+
+const llmFallbacksDTOKeys = ["id", "priority", "createdAt", "updatedAt", "provider"] as const;
+
+export interface LlmFallbacksDTO
+  extends Pick<LlmFallbacks, (typeof llmFallbacksDTOKeys)[number]> {}
+
+export const toLlmFallbacksDTO = (llmFallbacks: LlmFallbacks): LlmFallbacksDTO =>
+  pickDTOFields(llmFallbacks, llmFallbacksDTOKeys);
+
+
+const llmFallbackEventsDTOKeys = ["id", "sessionId", "eventType"] as const;
+
+export interface LlmFallbackEventsDTO
+  extends Pick<LlmFallbackEvents, (typeof llmFallbackEventsDTOKeys)[number]> {}
+
+export const toLlmFallbackEventsDTO = (llmFallbackEvents: LlmFallbackEvents): LlmFallbackEventsDTO =>
+  pickDTOFields(llmFallbackEvents, llmFallbackEventsDTOKeys);
+
+
+const llmUsageAnalyticsDTOKeys = ["id", "createdAt", "llmId"] as const;
+
+export interface LlmUsageAnalyticsDTO
+  extends Pick<LlmUsageAnalytics, (typeof llmUsageAnalyticsDTOKeys)[number]> {}
+
+export const toLlmUsageAnalyticsDTO = (llmUsageAnalytics: LlmUsageAnalytics): LlmUsageAnalyticsDTO =>
+  pickDTOFields(llmUsageAnalytics, llmUsageAnalyticsDTOKeys);
+
+
+const migrationEventsDTOKeys = ["id", "status", "eventType"] as const;
+
+export interface MigrationEventsDTO
+  extends Pick<MigrationEvents, (typeof migrationEventsDTOKeys)[number]> {}
+
+export const toMigrationEventsDTO = (migrationEvents: MigrationEvents): MigrationEventsDTO =>
+  pickDTOFields(migrationEvents, migrationEventsDTOKeys);
+

--- a/shared/federationTables.ts
+++ b/shared/federationTables.ts
@@ -1,6 +1,7 @@
 import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, real, uuid } from "drizzle-orm/pg-core";
-import { relations } from "drizzle-orm";
+import { InferSelectModel, relations } from "drizzle-orm";
 import { neurons } from "./schema";
+import { pickDTOFields } from "./dtoHelpers";
 
 // ===========================================
 // BILLION-DOLLAR FEDERATION BRIDGE TABLES
@@ -226,12 +227,94 @@ export const federationSecurityTokensRelations = relations(federationSecurityTok
 // TYPES
 // ===========================================
 
-export type FederationEvent = typeof federationEvents.$inferSelect;
-export type FederationSyncJob = typeof federationSyncJobs.$inferSelect;
-export type FederationConfigVersion = typeof federationConfigVersions.$inferSelect;
-export type FederationHotReload = typeof federationHotReloads.$inferSelect;
-export type FederationHealthCheck = typeof federationHealthChecks.$inferSelect;
-export type FederationConflict = typeof federationConflicts.$inferSelect;
-export type FederationMigration = typeof federationMigrations.$inferSelect;
-export type FederationAnalytic = typeof federationAnalytics.$inferSelect;
-export type FederationSecurityToken = typeof federationSecurityTokens.$inferSelect;
+export type FederationEvent = InferSelectModel<typeof federationEvents>;
+export type FederationSyncJob = InferSelectModel<typeof federationSyncJobs>;
+export type FederationConfigVersion = InferSelectModel<typeof federationConfigVersions>;
+export type FederationHotReload = InferSelectModel<typeof federationHotReloads>;
+export type FederationHealthCheck = InferSelectModel<typeof federationHealthChecks>;
+export type FederationConflict = InferSelectModel<typeof federationConflicts>;
+export type FederationMigration = InferSelectModel<typeof federationMigrations>;
+export type FederationAnalytic = InferSelectModel<typeof federationAnalytics>;
+export type FederationSecurityToken = InferSelectModel<typeof federationSecurityTokens>;
+
+// DTOs
+const federationEventDTOKeys = ["id", "neuronId", "eventType"] as const;
+
+export interface FederationEventDTO
+  extends Pick<FederationEvent, (typeof federationEventDTOKeys)[number]> {}
+
+export const toFederationEventDTO = (federationEvent: FederationEvent): FederationEventDTO =>
+  pickDTOFields(federationEvent, federationEventDTOKeys);
+
+
+const federationSyncJobDTOKeys = ["id", "status", "createdAt"] as const;
+
+export interface FederationSyncJobDTO
+  extends Pick<FederationSyncJob, (typeof federationSyncJobDTOKeys)[number]> {}
+
+export const toFederationSyncJobDTO = (federationSyncJob: FederationSyncJob): FederationSyncJobDTO =>
+  pickDTOFields(federationSyncJob, federationSyncJobDTOKeys);
+
+
+const federationConfigVersionDTOKeys = ["id", "createdAt", "version"] as const;
+
+export interface FederationConfigVersionDTO
+  extends Pick<FederationConfigVersion, (typeof federationConfigVersionDTOKeys)[number]> {}
+
+export const toFederationConfigVersionDTO = (federationConfigVersion: FederationConfigVersion): FederationConfigVersionDTO =>
+  pickDTOFields(federationConfigVersion, federationConfigVersionDTOKeys);
+
+
+const federationHotReloadDTOKeys = ["id", "status", "neuronId"] as const;
+
+export interface FederationHotReloadDTO
+  extends Pick<FederationHotReload, (typeof federationHotReloadDTOKeys)[number]> {}
+
+export const toFederationHotReloadDTO = (federationHotReload: FederationHotReload): FederationHotReloadDTO =>
+  pickDTOFields(federationHotReload, federationHotReloadDTOKeys);
+
+
+const federationHealthCheckDTOKeys = ["id", "status", "neuronId"] as const;
+
+export interface FederationHealthCheckDTO
+  extends Pick<FederationHealthCheck, (typeof federationHealthCheckDTOKeys)[number]> {}
+
+export const toFederationHealthCheckDTO = (federationHealthCheck: FederationHealthCheck): FederationHealthCheckDTO =>
+  pickDTOFields(federationHealthCheck, federationHealthCheckDTOKeys);
+
+
+const federationConflictDTOKeys = ["id", "status", "neuronId", "priority", "createdAt"] as const;
+
+export interface FederationConflictDTO
+  extends Pick<FederationConflict, (typeof federationConflictDTOKeys)[number]> {}
+
+export const toFederationConflictDTO = (federationConflict: FederationConflict): FederationConflictDTO =>
+  pickDTOFields(federationConflict, federationConflictDTOKeys);
+
+
+const federationMigrationDTOKeys = ["id", "status", "neuronId", "createdAt"] as const;
+
+export interface FederationMigrationDTO
+  extends Pick<FederationMigration, (typeof federationMigrationDTOKeys)[number]> {}
+
+export const toFederationMigrationDTO = (federationMigration: FederationMigration): FederationMigrationDTO =>
+  pickDTOFields(federationMigration, federationMigrationDTOKeys);
+
+
+const federationAnalyticDTOKeys = ["id", "neuronId", "createdAt"] as const;
+
+export interface FederationAnalyticDTO
+  extends Pick<FederationAnalytic, (typeof federationAnalyticDTOKeys)[number]> {}
+
+export const toFederationAnalyticDTO = (federationAnalytic: FederationAnalytic): FederationAnalyticDTO =>
+  pickDTOFields(federationAnalytic, federationAnalyticDTOKeys);
+
+
+const federationSecurityTokenDTOKeys = ["id", "neuronId", "createdAt"] as const;
+
+export interface FederationSecurityTokenDTO
+  extends Pick<FederationSecurityToken, (typeof federationSecurityTokenDTOKeys)[number]> {}
+
+export const toFederationSecurityTokenDTO = (federationSecurityToken: FederationSecurityToken): FederationSecurityTokenDTO =>
+  pickDTOFields(federationSecurityToken, federationSecurityTokenDTOKeys);
+

--- a/shared/financeTables.ts
+++ b/shared/financeTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, dec
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // Finance User Profiles - Track financial personas and goals
 export const financeProfiles = pgTable("finance_profiles", {
   id: serial("id").primaryKey(),
@@ -211,22 +213,104 @@ export const insertFinanceLeadMagnetSchema = createInsertSchema(financeLeadMagne
 export const insertFinancePerformanceMetricSchema = createInsertSchema(financePerformanceMetrics).omit({ id: true, createdAt: true });
 
 // Type exports
-export type InsertFinanceProfile = z.infer<typeof insertFinanceProfileSchema>;
-export type InsertFinanceQuizResult = z.infer<typeof insertFinanceQuizResultSchema>;
-export type InsertFinanceCalculatorResult = z.infer<typeof insertFinanceCalculatorResultSchema>;
-export type InsertFinanceProductOffer = z.infer<typeof insertFinanceProductOfferSchema>;
-export type InsertFinanceContent = z.infer<typeof insertFinanceContentSchema>;
-export type InsertFinanceGamification = z.infer<typeof insertFinanceGamificationSchema>;
-export type InsertFinanceAIChatSession = z.infer<typeof insertFinanceAIChatSessionSchema>;
-export type InsertFinanceLeadMagnet = z.infer<typeof insertFinanceLeadMagnetSchema>;
-export type InsertFinancePerformanceMetric = z.infer<typeof insertFinancePerformanceMetricSchema>;
+export type InsertFinanceProfile = InferInsertModel<typeof financeProfiles>;
+export type InsertFinanceQuizResult = InferInsertModel<typeof financeQuizResults>;
+export type InsertFinanceCalculatorResult = InferInsertModel<typeof financeCalculatorResults>;
+export type InsertFinanceProductOffer = InferInsertModel<typeof financeProductOffers>;
+export type InsertFinanceContent = InferInsertModel<typeof financeContent>;
+export type InsertFinanceGamification = InferInsertModel<typeof financeGamification>;
+export type InsertFinanceAIChatSession = InferInsertModel<typeof financeAIChatSessions>;
+export type InsertFinanceLeadMagnet = InferInsertModel<typeof financeLeadMagnets>;
+export type InsertFinancePerformanceMetric = InferInsertModel<typeof financePerformanceMetrics>;
 
-export type FinanceProfile = typeof financeProfiles.$inferSelect;
-export type FinanceQuizResult = typeof financeQuizResults.$inferSelect;
-export type FinanceCalculatorResult = typeof financeCalculatorResults.$inferSelect;
-export type FinanceProductOffer = typeof financeProductOffers.$inferSelect;
-export type FinanceContent = typeof financeContent.$inferSelect;
-export type FinanceGamification = typeof financeGamification.$inferSelect;
-export type FinanceAIChatSession = typeof financeAIChatSessions.$inferSelect;
-export type FinanceLeadMagnet = typeof financeLeadMagnets.$inferSelect;
-export type FinancePerformanceMetric = typeof financePerformanceMetrics.$inferSelect;
+export type FinanceProfile = InferSelectModel<typeof financeProfiles>;
+export type FinanceQuizResult = InferSelectModel<typeof financeQuizResults>;
+export type FinanceCalculatorResult = InferSelectModel<typeof financeCalculatorResults>;
+export type FinanceProductOffer = InferSelectModel<typeof financeProductOffers>;
+export type FinanceContent = InferSelectModel<typeof financeContent>;
+export type FinanceGamification = InferSelectModel<typeof financeGamification>;
+export type FinanceAIChatSession = InferSelectModel<typeof financeAIChatSessions>;
+export type FinanceLeadMagnet = InferSelectModel<typeof financeLeadMagnets>;
+export type FinancePerformanceMetric = InferSelectModel<typeof financePerformanceMetrics>;
+
+// DTOs
+const financeProfileDTOKeys = ["id", "sessionId", "userId", "createdAt", "updatedAt"] as const;
+
+export interface FinanceProfileDTO
+  extends Pick<FinanceProfile, (typeof financeProfileDTOKeys)[number]> {}
+
+export const toFinanceProfileDTO = (financeProfile: FinanceProfile): FinanceProfileDTO =>
+  pickDTOFields(financeProfile, financeProfileDTOKeys);
+
+
+const financeQuizResultDTOKeys = ["id", "sessionId", "userId", "createdAt", "quizType"] as const;
+
+export interface FinanceQuizResultDTO
+  extends Pick<FinanceQuizResult, (typeof financeQuizResultDTOKeys)[number]> {}
+
+export const toFinanceQuizResultDTO = (financeQuizResult: FinanceQuizResult): FinanceQuizResultDTO =>
+  pickDTOFields(financeQuizResult, financeQuizResultDTOKeys);
+
+
+const financeCalculatorResultDTOKeys = ["id", "sessionId", "userId", "createdAt"] as const;
+
+export interface FinanceCalculatorResultDTO
+  extends Pick<FinanceCalculatorResult, (typeof financeCalculatorResultDTOKeys)[number]> {}
+
+export const toFinanceCalculatorResultDTO = (financeCalculatorResult: FinanceCalculatorResult): FinanceCalculatorResultDTO =>
+  pickDTOFields(financeCalculatorResult, financeCalculatorResultDTOKeys);
+
+
+const financeProductOfferDTOKeys = ["id", "priority", "createdAt", "updatedAt", "description"] as const;
+
+export interface FinanceProductOfferDTO
+  extends Pick<FinanceProductOffer, (typeof financeProductOfferDTOKeys)[number]> {}
+
+export const toFinanceProductOfferDTO = (financeProductOffer: FinanceProductOffer): FinanceProductOfferDTO =>
+  pickDTOFields(financeProductOffer, financeProductOfferDTOKeys);
+
+
+const financeContentDTOKeys = ["id", "title", "slug", "category", "createdAt", "updatedAt"] as const;
+
+export interface FinanceContentDTO
+  extends Pick<FinanceContent, (typeof financeContentDTOKeys)[number]> {}
+
+export const toFinanceContentDTO = (financeContent: FinanceContent): FinanceContentDTO =>
+  pickDTOFields(financeContent, financeContentDTOKeys);
+
+
+const financeGamificationDTOKeys = ["id", "sessionId", "userId", "createdAt", "updatedAt"] as const;
+
+export interface FinanceGamificationDTO
+  extends Pick<FinanceGamification, (typeof financeGamificationDTOKeys)[number]> {}
+
+export const toFinanceGamificationDTO = (financeGamification: FinanceGamification): FinanceGamificationDTO =>
+  pickDTOFields(financeGamification, financeGamificationDTOKeys);
+
+
+const financeAIChatSessionDTOKeys = ["id", "sessionId", "userId", "createdAt", "updatedAt"] as const;
+
+export interface FinanceAIChatSessionDTO
+  extends Pick<FinanceAIChatSession, (typeof financeAIChatSessionDTOKeys)[number]> {}
+
+export const toFinanceAIChatSessionDTO = (financeAIChatSession: FinanceAIChatSession): FinanceAIChatSessionDTO =>
+  pickDTOFields(financeAIChatSession, financeAIChatSessionDTOKeys);
+
+
+const financeLeadMagnetDTOKeys = ["id", "sessionId", "userId", "createdAt"] as const;
+
+export interface FinanceLeadMagnetDTO
+  extends Pick<FinanceLeadMagnet, (typeof financeLeadMagnetDTOKeys)[number]> {}
+
+export const toFinanceLeadMagnetDTO = (financeLeadMagnet: FinanceLeadMagnet): FinanceLeadMagnetDTO =>
+  pickDTOFields(financeLeadMagnet, financeLeadMagnetDTOKeys);
+
+
+const financePerformanceMetricDTOKeys = ["id", "createdAt", "metricDate"] as const;
+
+export interface FinancePerformanceMetricDTO
+  extends Pick<FinancePerformanceMetric, (typeof financePerformanceMetricDTOKeys)[number]> {}
+
+export const toFinancePerformanceMetricDTO = (financePerformanceMetric: FinancePerformanceMetric): FinancePerformanceMetricDTO =>
+  pickDTOFields(financePerformanceMetric, financePerformanceMetricDTOKeys);
+

--- a/shared/franchiseExpansionTables.ts
+++ b/shared/franchiseExpansionTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // ================================================
 // CONTENT FRANCHISE EXPANSION KIT MODULE
 // Billion-Dollar Empire Grade, Infinite Scaling, Migration-Proof
@@ -290,19 +292,104 @@ export const insertFranchiseBackupSchema = createInsertSchema(franchiseBackups);
 export const insertFranchiseManagementDashboardSchema = createInsertSchema(franchiseManagementDashboard);
 
 // Types
-export type FranchiseTemplate = typeof franchiseTemplates.$inferSelect;
-export type NewFranchiseTemplate = typeof franchiseTemplates.$inferInsert;
-export type FranchiseInstance = typeof franchiseInstances.$inferSelect;
-export type NewFranchiseInstance = typeof franchiseInstances.$inferInsert;
-export type FranchiseDeployment = typeof franchiseDeployments.$inferSelect;
-export type NewFranchiseDeployment = typeof franchiseDeployments.$inferInsert;
-export type CrossPromotionLink = typeof crossPromotionLinks.$inferSelect;
-export type NewCrossPromotionLink = typeof crossPromotionLinks.$inferInsert;
-export type FranchiseAnalytic = typeof franchiseAnalytics.$inferSelect;
-export type NewFranchiseAnalytic = typeof franchiseAnalytics.$inferInsert;
-export type FranchiseUpdate = typeof franchiseUpdates.$inferSelect;
-export type NewFranchiseUpdate = typeof franchiseUpdates.$inferInsert;
-export type FranchiseBackup = typeof franchiseBackups.$inferSelect;
-export type NewFranchiseBackup = typeof franchiseBackups.$inferInsert;
-export type FranchiseManagementDashboard = typeof franchiseManagementDashboard.$inferSelect;
-export type NewFranchiseManagementDashboard = typeof franchiseManagementDashboard.$inferInsert;
+export type FranchiseTemplate = InferSelectModel<typeof franchiseTemplates>;
+export type NewFranchiseTemplate = InferInsertModel<typeof franchiseTemplates>;
+export type FranchiseInstance = InferSelectModel<typeof franchiseInstances>;
+export type NewFranchiseInstance = InferInsertModel<typeof franchiseInstances>;
+export type FranchiseDeployment = InferSelectModel<typeof franchiseDeployments>;
+export type NewFranchiseDeployment = InferInsertModel<typeof franchiseDeployments>;
+export type CrossPromotionLink = InferSelectModel<typeof crossPromotionLinks>;
+export type NewCrossPromotionLink = InferInsertModel<typeof crossPromotionLinks>;
+export type FranchiseAnalytic = InferSelectModel<typeof franchiseAnalytics>;
+export type NewFranchiseAnalytic = InferInsertModel<typeof franchiseAnalytics>;
+export type FranchiseUpdate = InferSelectModel<typeof franchiseUpdates>;
+export type NewFranchiseUpdate = InferInsertModel<typeof franchiseUpdates>;
+export type FranchiseBackup = InferSelectModel<typeof franchiseBackups>;
+export type NewFranchiseBackup = InferInsertModel<typeof franchiseBackups>;
+export type FranchiseManagementDashboard = InferSelectModel<typeof franchiseManagementDashboard>;
+export type NewFranchiseManagementDashboard = InferInsertModel<typeof franchiseManagementDashboard>;
+
+export type FranchiseOpportunity = InferSelectModel<typeof franchiseOpportunities>;
+export type InsertFranchiseOpportunity = InferInsertModel<typeof franchiseOpportunities>;
+
+// DTOs
+const franchiseTemplateDTOKeys = ["id", "category", "createdAt", "updatedAt", "description", "version"] as const;
+
+export interface FranchiseTemplateDTO
+  extends Pick<FranchiseTemplate, (typeof franchiseTemplateDTOKeys)[number]> {}
+
+export const toFranchiseTemplateDTO = (franchiseTemplate: FranchiseTemplate): FranchiseTemplateDTO =>
+  pickDTOFields(franchiseTemplate, franchiseTemplateDTOKeys);
+
+
+const franchiseInstanceDTOKeys = ["id", "status", "region", "language", "createdAt", "updatedAt"] as const;
+
+export interface FranchiseInstanceDTO
+  extends Pick<FranchiseInstance, (typeof franchiseInstanceDTOKeys)[number]> {}
+
+export const toFranchiseInstanceDTO = (franchiseInstance: FranchiseInstance): FranchiseInstanceDTO =>
+  pickDTOFields(franchiseInstance, franchiseInstanceDTOKeys);
+
+
+const franchiseDeploymentDTOKeys = ["id", "createdAt", "version"] as const;
+
+export interface FranchiseDeploymentDTO
+  extends Pick<FranchiseDeployment, (typeof franchiseDeploymentDTOKeys)[number]> {}
+
+export const toFranchiseDeploymentDTO = (franchiseDeployment: FranchiseDeployment): FranchiseDeploymentDTO =>
+  pickDTOFields(franchiseDeployment, franchiseDeploymentDTOKeys);
+
+
+const crossPromotionLinkDTOKeys = ["id", "priority", "createdAt", "updatedAt"] as const;
+
+export interface CrossPromotionLinkDTO
+  extends Pick<CrossPromotionLink, (typeof crossPromotionLinkDTOKeys)[number]> {}
+
+export const toCrossPromotionLinkDTO = (crossPromotionLink: CrossPromotionLink): CrossPromotionLinkDTO =>
+  pickDTOFields(crossPromotionLink, crossPromotionLinkDTOKeys);
+
+
+const franchiseAnalyticDTOKeys = ["id", "createdAt", "franchiseId"] as const;
+
+export interface FranchiseAnalyticDTO
+  extends Pick<FranchiseAnalytic, (typeof franchiseAnalyticDTOKeys)[number]> {}
+
+export const toFranchiseAnalyticDTO = (franchiseAnalytic: FranchiseAnalytic): FranchiseAnalyticDTO =>
+  pickDTOFields(franchiseAnalytic, franchiseAnalyticDTOKeys);
+
+
+const franchiseUpdateDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface FranchiseUpdateDTO
+  extends Pick<FranchiseUpdate, (typeof franchiseUpdateDTOKeys)[number]> {}
+
+export const toFranchiseUpdateDTO = (franchiseUpdate: FranchiseUpdate): FranchiseUpdateDTO =>
+  pickDTOFields(franchiseUpdate, franchiseUpdateDTOKeys);
+
+
+const franchiseBackupDTOKeys = ["id", "createdAt", "franchiseId"] as const;
+
+export interface FranchiseBackupDTO
+  extends Pick<FranchiseBackup, (typeof franchiseBackupDTOKeys)[number]> {}
+
+export const toFranchiseBackupDTO = (franchiseBackup: FranchiseBackup): FranchiseBackupDTO =>
+  pickDTOFields(franchiseBackup, franchiseBackupDTOKeys);
+
+
+const franchiseManagementDashboardDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface FranchiseManagementDashboardDTO
+  extends Pick<FranchiseManagementDashboard, (typeof franchiseManagementDashboardDTOKeys)[number]> {}
+
+export const toFranchiseManagementDashboardDTO = (franchiseManagementDashboard: FranchiseManagementDashboard): FranchiseManagementDashboardDTO =>
+  pickDTOFields(franchiseManagementDashboard, franchiseManagementDashboardDTOKeys);
+
+
+const franchiseOpportunityDTOKeys = ["id", "region", "country", "priority", "createdAt", "updatedAt"] as const;
+
+export interface FranchiseOpportunityDTO
+  extends Pick<FranchiseOpportunity, (typeof franchiseOpportunityDTOKeys)[number]> {}
+
+export const toFranchiseOpportunityDTO = (franchiseOpportunity: FranchiseOpportunity): FranchiseOpportunityDTO =>
+  pickDTOFields(franchiseOpportunity, franchiseOpportunityDTOKeys);
+

--- a/shared/funnelTables.ts
+++ b/shared/funnelTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // Funnel Templates - Core funnel definitions
 export const funnelTemplates = pgTable("funnel_templates", {
   id: serial("id").primaryKey(),
@@ -317,26 +319,99 @@ export const insertFunnelIntegrationSchema = createInsertSchema(funnelIntegratio
 });
 
 // Type exports
-export type FunnelTemplate = typeof funnelTemplates.$inferSelect;
-export type InsertFunnelTemplate = z.infer<typeof insertFunnelTemplateSchema>;
+export type FunnelTemplate = InferSelectModel<typeof funnelTemplates>;
+export type InsertFunnelTemplate = InferInsertModel<typeof funnelTemplates>;
 
-export type FunnelBlock = typeof funnelBlocks.$inferSelect;
-export type InsertFunnelBlock = z.infer<typeof insertFunnelBlockSchema>;
+export type FunnelBlock = InferSelectModel<typeof funnelBlocks>;
+export type InsertFunnelBlock = InferInsertModel<typeof funnelBlocks>;
 
-export type UserFunnelSession = typeof userFunnelSessions.$inferSelect;
-export type InsertUserFunnelSession = z.infer<typeof insertUserFunnelSessionSchema>;
+export type UserFunnelSession = InferSelectModel<typeof userFunnelSessions>;
+export type InsertUserFunnelSession = InferInsertModel<typeof userFunnelSessions>;
 
-export type FunnelEvent = typeof funnelEvents.$inferSelect;
-export type InsertFunnelEvent = z.infer<typeof insertFunnelEventSchema>;
+export type FunnelEvent = InferSelectModel<typeof funnelEvents>;
+export type InsertFunnelEvent = InferInsertModel<typeof funnelEvents>;
 
-export type FunnelAnalytics = typeof funnelAnalytics.$inferSelect;
-export type InsertFunnelAnalytics = z.infer<typeof insertFunnelAnalyticsSchema>;
+export type FunnelAnalytics = InferSelectModel<typeof funnelAnalytics>;
+export type InsertFunnelAnalytics = InferInsertModel<typeof funnelAnalytics>;
 
-export type FunnelABTest = typeof funnelABTests.$inferSelect;
-export type InsertFunnelABTest = z.infer<typeof insertFunnelABTestSchema>;
+export type FunnelABTest = InferSelectModel<typeof funnelABTests>;
+export type InsertFunnelABTest = InferInsertModel<typeof funnelABTests>;
 
-export type FunnelTrigger = typeof funnelTriggers.$inferSelect;
-export type InsertFunnelTrigger = z.infer<typeof insertFunnelTriggerSchema>;
+export type FunnelTrigger = InferSelectModel<typeof funnelTriggers>;
+export type InsertFunnelTrigger = InferInsertModel<typeof funnelTriggers>;
 
-export type FunnelIntegration = typeof funnelIntegrations.$inferSelect;
-export type InsertFunnelIntegration = z.infer<typeof insertFunnelIntegrationSchema>;
+export type FunnelIntegration = InferSelectModel<typeof funnelIntegrations>;
+export type InsertFunnelIntegration = InferInsertModel<typeof funnelIntegrations>;
+
+// DTOs
+const funnelTemplateDTOKeys = ["id", "name", "slug", "category", "createdAt", "updatedAt", "description", "version"] as const;
+
+export interface FunnelTemplateDTO
+  extends Pick<FunnelTemplate, (typeof funnelTemplateDTOKeys)[number]> {}
+
+export const toFunnelTemplateDTO = (funnelTemplate: FunnelTemplate): FunnelTemplateDTO =>
+  pickDTOFields(funnelTemplate, funnelTemplateDTOKeys);
+
+
+const funnelBlockDTOKeys = ["id", "name", "slug", "type", "category", "createdAt", "updatedAt"] as const;
+
+export interface FunnelBlockDTO
+  extends Pick<FunnelBlock, (typeof funnelBlockDTOKeys)[number]> {}
+
+export const toFunnelBlockDTO = (funnelBlock: FunnelBlock): FunnelBlockDTO =>
+  pickDTOFields(funnelBlock, funnelBlockDTOKeys);
+
+
+const userFunnelSessionDTOKeys = ["id", "status", "sessionId", "userId", "funnelId"] as const;
+
+export interface UserFunnelSessionDTO
+  extends Pick<UserFunnelSession, (typeof userFunnelSessionDTOKeys)[number]> {}
+
+export const toUserFunnelSessionDTO = (userFunnelSession: UserFunnelSession): UserFunnelSessionDTO =>
+  pickDTOFields(userFunnelSession, userFunnelSessionDTOKeys);
+
+
+const funnelEventDTOKeys = ["id", "sessionId", "eventType"] as const;
+
+export interface FunnelEventDTO
+  extends Pick<FunnelEvent, (typeof funnelEventDTOKeys)[number]> {}
+
+export const toFunnelEventDTO = (funnelEvent: FunnelEvent): FunnelEventDTO =>
+  pickDTOFields(funnelEvent, funnelEventDTOKeys);
+
+
+const funnelAnalyticsDTOKeys = ["id", "segment", "funnelId"] as const;
+
+export interface FunnelAnalyticsDTO
+  extends Pick<FunnelAnalytics, (typeof funnelAnalyticsDTOKeys)[number]> {}
+
+export const toFunnelAnalyticsDTO = (funnelAnalytics: FunnelAnalytics): FunnelAnalyticsDTO =>
+  pickDTOFields(funnelAnalytics, funnelAnalyticsDTOKeys);
+
+
+const funnelABTestDTOKeys = ["id", "name", "status", "createdAt", "updatedAt", "funnelId"] as const;
+
+export interface FunnelABTestDTO
+  extends Pick<FunnelABTest, (typeof funnelABTestDTOKeys)[number]> {}
+
+export const toFunnelABTestDTO = (funnelABTest: FunnelABTest): FunnelABTestDTO =>
+  pickDTOFields(funnelABTest, funnelABTestDTOKeys);
+
+
+const funnelTriggerDTOKeys = ["id", "name", "priority", "createdAt", "updatedAt", "funnelId"] as const;
+
+export interface FunnelTriggerDTO
+  extends Pick<FunnelTrigger, (typeof funnelTriggerDTOKeys)[number]> {}
+
+export const toFunnelTriggerDTO = (funnelTrigger: FunnelTrigger): FunnelTriggerDTO =>
+  pickDTOFields(funnelTrigger, funnelTriggerDTOKeys);
+
+
+const funnelIntegrationDTOKeys = ["id", "name", "type", "createdAt", "updatedAt"] as const;
+
+export interface FunnelIntegrationDTO
+  extends Pick<FunnelIntegration, (typeof funnelIntegrationDTOKeys)[number]> {}
+
+export const toFunnelIntegrationDTO = (funnelIntegration: FunnelIntegration): FunnelIntegrationDTO =>
+  pickDTOFields(funnelIntegration, funnelIntegrationDTOKeys);
+

--- a/shared/healthTables.ts
+++ b/shared/healthTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // Health & Wellness User Archetypes
 export const healthArchetypes = pgTable("health_archetypes", {
   id: serial("id").primaryKey(),
@@ -205,25 +207,125 @@ export const insertHealthQuestCompletionSchema = createInsertSchema(healthQuestC
 export const insertHealthContentPerformanceSchema = createInsertSchema(healthContentPerformance);
 
 // Type exports
-export type HealthArchetype = typeof healthArchetypes.$inferSelect;
-export type InsertHealthArchetype = z.infer<typeof insertHealthArchetypeSchema>;
-export type HealthTool = typeof healthTools.$inferSelect;
-export type InsertHealthTool = z.infer<typeof insertHealthToolSchema>;
-export type HealthToolSession = typeof healthToolSessions.$inferSelect;
-export type InsertHealthToolSession = z.infer<typeof insertHealthToolSessionSchema>;
-export type HealthQuiz = typeof healthQuizzes.$inferSelect;
-export type InsertHealthQuiz = z.infer<typeof insertHealthQuizSchema>;
-export type HealthQuizResult = typeof healthQuizResults.$inferSelect;
-export type InsertHealthQuizResult = z.infer<typeof insertHealthQuizResultSchema>;
-export type HealthContent = typeof healthContent.$inferSelect;
-export type InsertHealthContent = z.infer<typeof insertHealthContentSchema>;
-export type HealthLeadMagnet = typeof healthLeadMagnets.$inferSelect;
-export type InsertHealthLeadMagnet = z.infer<typeof insertHealthLeadMagnetSchema>;
-export type HealthGamification = typeof healthGamification.$inferSelect;
-export type InsertHealthGamification = z.infer<typeof insertHealthGamificationSchema>;
-export type HealthDailyQuest = typeof healthDailyQuests.$inferSelect;
-export type InsertHealthDailyQuest = z.infer<typeof insertHealthDailyQuestSchema>;
-export type HealthQuestCompletion = typeof healthQuestCompletions.$inferSelect;
-export type InsertHealthQuestCompletion = z.infer<typeof insertHealthQuestCompletionSchema>;
-export type HealthContentPerformance = typeof healthContentPerformance.$inferSelect;
-export type InsertHealthContentPerformance = z.infer<typeof insertHealthContentPerformanceSchema>;
+export type HealthArchetype = InferSelectModel<typeof healthArchetypes>;
+export type InsertHealthArchetype = InferInsertModel<typeof healthArchetypes>;
+export type HealthTool = InferSelectModel<typeof healthTools>;
+export type InsertHealthTool = InferInsertModel<typeof healthTools>;
+export type HealthToolSession = InferSelectModel<typeof healthToolSessions>;
+export type InsertHealthToolSession = InferInsertModel<typeof healthToolSessions>;
+export type HealthQuiz = InferSelectModel<typeof healthQuizzes>;
+export type InsertHealthQuiz = InferInsertModel<typeof healthQuizzes>;
+export type HealthQuizResult = InferSelectModel<typeof healthQuizResults>;
+export type InsertHealthQuizResult = InferInsertModel<typeof healthQuizResults>;
+export type HealthContent = InferSelectModel<typeof healthContent>;
+export type InsertHealthContent = InferInsertModel<typeof healthContent>;
+export type HealthLeadMagnet = InferSelectModel<typeof healthLeadMagnets>;
+export type InsertHealthLeadMagnet = InferInsertModel<typeof healthLeadMagnets>;
+export type HealthGamification = InferSelectModel<typeof healthGamification>;
+export type InsertHealthGamification = InferInsertModel<typeof healthGamification>;
+export type HealthDailyQuest = InferSelectModel<typeof healthDailyQuests>;
+export type InsertHealthDailyQuest = InferInsertModel<typeof healthDailyQuests>;
+export type HealthQuestCompletion = InferSelectModel<typeof healthQuestCompletions>;
+export type InsertHealthQuestCompletion = InferInsertModel<typeof healthQuestCompletions>;
+export type HealthContentPerformance = InferSelectModel<typeof healthContentPerformance>;
+export type InsertHealthContentPerformance = InferInsertModel<typeof healthContentPerformance>;
+
+// DTOs
+const healthArchetypeDTOKeys = ["id", "name", "slug", "createdAt", "updatedAt", "description"] as const;
+
+export interface HealthArchetypeDTO
+  extends Pick<HealthArchetype, (typeof healthArchetypeDTOKeys)[number]> {}
+
+export const toHealthArchetypeDTO = (healthArchetype: HealthArchetype): HealthArchetypeDTO =>
+  pickDTOFields(healthArchetype, healthArchetypeDTOKeys);
+
+
+const healthToolDTOKeys = ["id", "name", "slug", "category", "createdAt", "updatedAt", "description"] as const;
+
+export interface HealthToolDTO
+  extends Pick<HealthTool, (typeof healthToolDTOKeys)[number]> {}
+
+export const toHealthToolDTO = (healthTool: HealthTool): HealthToolDTO =>
+  pickDTOFields(healthTool, healthToolDTOKeys);
+
+
+const healthToolSessionDTOKeys = ["id", "sessionId", "userId", "createdAt", "toolId"] as const;
+
+export interface HealthToolSessionDTO
+  extends Pick<HealthToolSession, (typeof healthToolSessionDTOKeys)[number]> {}
+
+export const toHealthToolSessionDTO = (healthToolSession: HealthToolSession): HealthToolSessionDTO =>
+  pickDTOFields(healthToolSession, healthToolSessionDTOKeys);
+
+
+const healthQuizDTOKeys = ["id", "title", "slug", "category", "createdAt", "updatedAt", "description"] as const;
+
+export interface HealthQuizDTO
+  extends Pick<HealthQuiz, (typeof healthQuizDTOKeys)[number]> {}
+
+export const toHealthQuizDTO = (healthQuiz: HealthQuiz): HealthQuizDTO =>
+  pickDTOFields(healthQuiz, healthQuizDTOKeys);
+
+
+const healthQuizResultDTOKeys = ["id", "sessionId", "userId", "createdAt"] as const;
+
+export interface HealthQuizResultDTO
+  extends Pick<HealthQuizResult, (typeof healthQuizResultDTOKeys)[number]> {}
+
+export const toHealthQuizResultDTO = (healthQuizResult: HealthQuizResult): HealthQuizResultDTO =>
+  pickDTOFields(healthQuizResult, healthQuizResultDTOKeys);
+
+
+const healthContentDTOKeys = ["id", "title", "slug", "category", "createdAt", "updatedAt"] as const;
+
+export interface HealthContentDTO
+  extends Pick<HealthContent, (typeof healthContentDTOKeys)[number]> {}
+
+export const toHealthContentDTO = (healthContent: HealthContent): HealthContentDTO =>
+  pickDTOFields(healthContent, healthContentDTOKeys);
+
+
+const healthLeadMagnetDTOKeys = ["id", "title", "slug", "category", "createdAt", "updatedAt", "description"] as const;
+
+export interface HealthLeadMagnetDTO
+  extends Pick<HealthLeadMagnet, (typeof healthLeadMagnetDTOKeys)[number]> {}
+
+export const toHealthLeadMagnetDTO = (healthLeadMagnet: HealthLeadMagnet): HealthLeadMagnetDTO =>
+  pickDTOFields(healthLeadMagnet, healthLeadMagnetDTOKeys);
+
+
+const healthGamificationDTOKeys = ["id", "sessionId", "userId", "createdAt", "updatedAt"] as const;
+
+export interface HealthGamificationDTO
+  extends Pick<HealthGamification, (typeof healthGamificationDTOKeys)[number]> {}
+
+export const toHealthGamificationDTO = (healthGamification: HealthGamification): HealthGamificationDTO =>
+  pickDTOFields(healthGamification, healthGamificationDTOKeys);
+
+
+const healthDailyQuestDTOKeys = ["id", "title", "slug", "category", "createdAt", "updatedAt", "description"] as const;
+
+export interface HealthDailyQuestDTO
+  extends Pick<HealthDailyQuest, (typeof healthDailyQuestDTOKeys)[number]> {}
+
+export const toHealthDailyQuestDTO = (healthDailyQuest: HealthDailyQuest): HealthDailyQuestDTO =>
+  pickDTOFields(healthDailyQuest, healthDailyQuestDTOKeys);
+
+
+const healthQuestCompletionDTOKeys = ["id", "sessionId", "userId", "createdAt"] as const;
+
+export interface HealthQuestCompletionDTO
+  extends Pick<HealthQuestCompletion, (typeof healthQuestCompletionDTOKeys)[number]> {}
+
+export const toHealthQuestCompletionDTO = (healthQuestCompletion: HealthQuestCompletion): HealthQuestCompletionDTO =>
+  pickDTOFields(healthQuestCompletion, healthQuestCompletionDTOKeys);
+
+
+const healthContentPerformanceDTOKeys = ["id", "createdAt", "contentId"] as const;
+
+export interface HealthContentPerformanceDTO
+  extends Pick<HealthContentPerformance, (typeof healthContentPerformanceDTOKeys)[number]> {}
+
+export const toHealthContentPerformanceDTO = (healthContentPerformance: HealthContentPerformance): HealthContentPerformanceDTO =>
+  pickDTOFields(healthContentPerformance, healthContentPerformanceDTOKeys);
+

--- a/shared/knowledgeMemoryTables.ts
+++ b/shared/knowledgeMemoryTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // ==========================================
 // KNOWLEDGE MEMORY GRAPH TABLES
 // ==========================================
@@ -255,20 +257,20 @@ export const federationMemorySync = pgTable("federation_memory_sync", {
 }));
 
 // Type definitions for TypeScript support
-export type MemoryNode = typeof memoryNodes.$inferSelect;
-export type NewMemoryNode = typeof memoryNodes.$inferInsert;
-export type MemoryEdge = typeof memoryEdges.$inferSelect;
-export type NewMemoryEdge = typeof memoryEdges.$inferInsert;
-export type PromptOptimization = typeof promptOptimizations.$inferSelect;
-export type NewPromptOptimization = typeof promptOptimizations.$inferInsert;
-export type MemorySearchSession = typeof memorySearchSessions.$inferSelect;
-export type NewMemorySearchSession = typeof memorySearchSessions.$inferInsert;
-export type KnowledgeGraphVersion = typeof knowledgeGraphVersions.$inferSelect;
-export type NewKnowledgeGraphVersion = typeof knowledgeGraphVersions.$inferInsert;
-export type MemoryUsageAnalytics = typeof memoryUsageAnalytics.$inferSelect;
-export type NewMemoryUsageAnalytics = typeof memoryUsageAnalytics.$inferInsert;
-export type FederationMemorySync = typeof federationMemorySync.$inferSelect;
-export type NewFederationMemorySync = typeof federationMemorySync.$inferInsert;
+export type MemoryNode = InferSelectModel<typeof memoryNodes>;
+export type NewMemoryNode = InferInsertModel<typeof memoryNodes>;
+export type MemoryEdge = InferSelectModel<typeof memoryEdges>;
+export type NewMemoryEdge = InferInsertModel<typeof memoryEdges>;
+export type PromptOptimization = InferSelectModel<typeof promptOptimizations>;
+export type NewPromptOptimization = InferInsertModel<typeof promptOptimizations>;
+export type MemorySearchSession = InferSelectModel<typeof memorySearchSessions>;
+export type NewMemorySearchSession = InferInsertModel<typeof memorySearchSessions>;
+export type KnowledgeGraphVersion = InferSelectModel<typeof knowledgeGraphVersions>;
+export type NewKnowledgeGraphVersion = InferInsertModel<typeof knowledgeGraphVersions>;
+export type MemoryUsageAnalytics = InferSelectModel<typeof memoryUsageAnalytics>;
+export type NewMemoryUsageAnalytics = InferInsertModel<typeof memoryUsageAnalytics>;
+export type FederationMemorySync = InferSelectModel<typeof federationMemorySync>;
+export type NewFederationMemorySync = InferInsertModel<typeof federationMemorySync>;
 
 // Schema validations
 export const memoryNodeSchema = createInsertSchema(memoryNodes);
@@ -278,3 +280,67 @@ export const memorySearchSessionSchema = createInsertSchema(memorySearchSessions
 export const knowledgeGraphVersionSchema = createInsertSchema(knowledgeGraphVersions);
 export const memoryUsageAnalyticsSchema = createInsertSchema(memoryUsageAnalytics);
 export const federationMemorySyncSchema = createInsertSchema(federationMemorySync);
+
+// DTOs
+const memoryNodeDTOKeys = ["id", "title", "slug", "status", "createdAt", "summary", "version"] as const;
+
+export interface MemoryNodeDTO
+  extends Pick<MemoryNode, (typeof memoryNodeDTOKeys)[number]> {}
+
+export const toMemoryNodeDTO = (memoryNode: MemoryNode): MemoryNodeDTO =>
+  pickDTOFields(memoryNode, memoryNodeDTOKeys);
+
+
+const memoryEdgeDTOKeys = ["id", "status", "createdAt"] as const;
+
+export interface MemoryEdgeDTO
+  extends Pick<MemoryEdge, (typeof memoryEdgeDTOKeys)[number]> {}
+
+export const toMemoryEdgeDTO = (memoryEdge: MemoryEdge): MemoryEdgeDTO =>
+  pickDTOFields(memoryEdge, memoryEdgeDTOKeys);
+
+
+const promptOptimizationDTOKeys = ["id", "sessionId", "optimizationId"] as const;
+
+export interface PromptOptimizationDTO
+  extends Pick<PromptOptimization, (typeof promptOptimizationDTOKeys)[number]> {}
+
+export const toPromptOptimizationDTO = (promptOptimization: PromptOptimization): PromptOptimizationDTO =>
+  pickDTOFields(promptOptimization, promptOptimizationDTOKeys);
+
+
+const memorySearchSessionDTOKeys = ["id", "sessionId", "userId"] as const;
+
+export interface MemorySearchSessionDTO
+  extends Pick<MemorySearchSession, (typeof memorySearchSessionDTOKeys)[number]> {}
+
+export const toMemorySearchSessionDTO = (memorySearchSession: MemorySearchSession): MemorySearchSessionDTO =>
+  pickDTOFields(memorySearchSession, memorySearchSessionDTOKeys);
+
+
+const knowledgeGraphVersionDTOKeys = ["id", "versionId", "nodeId"] as const;
+
+export interface KnowledgeGraphVersionDTO
+  extends Pick<KnowledgeGraphVersion, (typeof knowledgeGraphVersionDTOKeys)[number]> {}
+
+export const toKnowledgeGraphVersionDTO = (knowledgeGraphVersion: KnowledgeGraphVersion): KnowledgeGraphVersionDTO =>
+  pickDTOFields(knowledgeGraphVersion, knowledgeGraphVersionDTOKeys);
+
+
+const memoryUsageAnalyticsDTOKeys = ["id", "sessionId", "userId"] as const;
+
+export interface MemoryUsageAnalyticsDTO
+  extends Pick<MemoryUsageAnalytics, (typeof memoryUsageAnalyticsDTOKeys)[number]> {}
+
+export const toMemoryUsageAnalyticsDTO = (memoryUsageAnalytics: MemoryUsageAnalytics): MemoryUsageAnalyticsDTO =>
+  pickDTOFields(memoryUsageAnalytics, memoryUsageAnalyticsDTOKeys);
+
+
+const federationMemorySyncDTOKeys = ["id", "syncId", "sourceNeuron"] as const;
+
+export interface FederationMemorySyncDTO
+  extends Pick<FederationMemorySync, (typeof federationMemorySyncDTOKeys)[number]> {}
+
+export const toFederationMemorySyncDTO = (federationMemorySync: FederationMemorySync): FederationMemorySyncDTO =>
+  pickDTOFields(federationMemorySync, federationMemorySyncDTOKeys);
+

--- a/shared/layoutMutationTables.ts
+++ b/shared/layoutMutationTables.ts
@@ -1,3 +1,5 @@
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 /**
  * Real-Time Layout Mutation Engine Database Schema
  * Enterprise-grade tables for dynamic layout mutations and personalization
@@ -296,3 +298,82 @@ export const layoutExperiments = pgTable("layout_experiments", {
   startDateIdx: index("layout_experiments_start_date_idx").on(table.startDate),
   baselineTemplateIdx: index("layout_experiments_baseline_template_idx").on(table.baselineTemplateId),
 }));
+
+export type LayoutMutationLayoutTemplate = InferSelectModel<typeof layoutTemplates>;
+export type InsertLayoutMutationLayoutTemplate = InferInsertModel<typeof layoutTemplates>;
+export type LayoutMutationLayoutBlock = InferSelectModel<typeof layoutBlocks>;
+export type InsertLayoutMutationLayoutBlock = InferInsertModel<typeof layoutBlocks>;
+export type LayoutMutationLayoutMutation = InferSelectModel<typeof layoutMutations>;
+export type InsertLayoutMutationLayoutMutation = InferInsertModel<typeof layoutMutations>;
+export type LayoutMutationUserLayoutSession = InferSelectModel<typeof userLayoutSessions>;
+export type InsertLayoutMutationUserLayoutSession = InferInsertModel<typeof userLayoutSessions>;
+export type LayoutMutationMutationHistory = InferSelectModel<typeof mutationHistory>;
+export type InsertLayoutMutationMutationHistory = InferInsertModel<typeof mutationHistory>;
+export type LayoutMutationLayoutPerformanceAnalytic = InferSelectModel<typeof layoutPerformanceAnalytics>;
+export type InsertLayoutMutationLayoutPerformanceAnalytic = InferInsertModel<typeof layoutPerformanceAnalytics>;
+export type LayoutMutationLayoutExperiment = InferSelectModel<typeof layoutExperiments>;
+export type InsertLayoutMutationLayoutExperiment = InferInsertModel<typeof layoutExperiments>;
+
+// DTOs
+const layoutMutationLayoutTemplateDTOKeys = ["id", "status", "createdAt", "updatedAt", "description", "version"] as const;
+
+export interface LayoutMutationLayoutTemplateDTO
+  extends Pick<LayoutMutationLayoutTemplate, (typeof layoutMutationLayoutTemplateDTOKeys)[number]> {}
+
+export const toLayoutMutationLayoutTemplateDTO = (layoutMutationLayoutTemplate: LayoutMutationLayoutTemplate): LayoutMutationLayoutTemplateDTO =>
+  pickDTOFields(layoutMutationLayoutTemplate, layoutMutationLayoutTemplateDTOKeys);
+
+
+const layoutMutationLayoutBlockDTOKeys = ["id", "priority", "createdAt", "updatedAt", "version"] as const;
+
+export interface LayoutMutationLayoutBlockDTO
+  extends Pick<LayoutMutationLayoutBlock, (typeof layoutMutationLayoutBlockDTOKeys)[number]> {}
+
+export const toLayoutMutationLayoutBlockDTO = (layoutMutationLayoutBlock: LayoutMutationLayoutBlock): LayoutMutationLayoutBlockDTO =>
+  pickDTOFields(layoutMutationLayoutBlock, layoutMutationLayoutBlockDTOKeys);
+
+
+const layoutMutationLayoutMutationDTOKeys = ["id", "priority", "createdAt", "updatedAt"] as const;
+
+export interface LayoutMutationLayoutMutationDTO
+  extends Pick<LayoutMutationLayoutMutation, (typeof layoutMutationLayoutMutationDTOKeys)[number]> {}
+
+export const toLayoutMutationLayoutMutationDTO = (layoutMutationLayoutMutation: LayoutMutationLayoutMutation): LayoutMutationLayoutMutationDTO =>
+  pickDTOFields(layoutMutationLayoutMutation, layoutMutationLayoutMutationDTOKeys);
+
+
+const layoutMutationUserLayoutSessionDTOKeys = ["id", "sessionId", "userId", "createdAt", "updatedAt"] as const;
+
+export interface LayoutMutationUserLayoutSessionDTO
+  extends Pick<LayoutMutationUserLayoutSession, (typeof layoutMutationUserLayoutSessionDTOKeys)[number]> {}
+
+export const toLayoutMutationUserLayoutSessionDTO = (layoutMutationUserLayoutSession: LayoutMutationUserLayoutSession): LayoutMutationUserLayoutSessionDTO =>
+  pickDTOFields(layoutMutationUserLayoutSession, layoutMutationUserLayoutSessionDTOKeys);
+
+
+const layoutMutationMutationHistoryDTOKeys = ["id", "sessionId", "createdAt"] as const;
+
+export interface LayoutMutationMutationHistoryDTO
+  extends Pick<LayoutMutationMutationHistory, (typeof layoutMutationMutationHistoryDTOKeys)[number]> {}
+
+export const toLayoutMutationMutationHistoryDTO = (layoutMutationMutationHistory: LayoutMutationMutationHistory): LayoutMutationMutationHistoryDTO =>
+  pickDTOFields(layoutMutationMutationHistory, layoutMutationMutationHistoryDTOKeys);
+
+
+const layoutMutationLayoutPerformanceAnalyticDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface LayoutMutationLayoutPerformanceAnalyticDTO
+  extends Pick<LayoutMutationLayoutPerformanceAnalytic, (typeof layoutMutationLayoutPerformanceAnalyticDTOKeys)[number]> {}
+
+export const toLayoutMutationLayoutPerformanceAnalyticDTO = (layoutMutationLayoutPerformanceAnalytic: LayoutMutationLayoutPerformanceAnalytic): LayoutMutationLayoutPerformanceAnalyticDTO =>
+  pickDTOFields(layoutMutationLayoutPerformanceAnalytic, layoutMutationLayoutPerformanceAnalyticDTOKeys);
+
+
+const layoutMutationLayoutExperimentDTOKeys = ["id", "status", "createdAt", "updatedAt", "budget"] as const;
+
+export interface LayoutMutationLayoutExperimentDTO
+  extends Pick<LayoutMutationLayoutExperiment, (typeof layoutMutationLayoutExperimentDTOKeys)[number]> {}
+
+export const toLayoutMutationLayoutExperimentDTO = (layoutMutationLayoutExperiment: LayoutMutationLayoutExperiment): LayoutMutationLayoutExperimentDTO =>
+  pickDTOFields(layoutMutationLayoutExperiment, layoutMutationLayoutExperimentDTOKeys);
+

--- a/shared/layoutTables.ts
+++ b/shared/layoutTables.ts
@@ -1,3 +1,5 @@
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 /**
  * Real-Time Layout Mutation Engine Database Schema
  * Billion-Dollar Empire Grade - Complete table definitions for layout management
@@ -226,23 +228,87 @@ export const layoutAbTestsRelations = relations(layoutAbTests, ({ one }) => ({
 }));
 
 // Type definitions for TypeScript
-export type LayoutTemplate = typeof layoutTemplates.$inferSelect;
-export type NewLayoutTemplate = typeof layoutTemplates.$inferInsert;
+export type LayoutTemplate = InferSelectModel<typeof layoutTemplates>;
+export type NewLayoutTemplate = InferInsertModel<typeof layoutTemplates>;
 
-export type LayoutInstance = typeof layoutInstances.$inferSelect;
-export type NewLayoutInstance = typeof layoutInstances.$inferInsert;
+export type LayoutInstance = InferSelectModel<typeof layoutInstances>;
+export type NewLayoutInstance = InferInsertModel<typeof layoutInstances>;
 
-export type LayoutMutation = typeof layoutMutations.$inferSelect;
-export type NewLayoutMutation = typeof layoutMutations.$inferInsert;
+export type LayoutMutation = InferSelectModel<typeof layoutMutations>;
+export type NewLayoutMutation = InferInsertModel<typeof layoutMutations>;
 
-export type LayoutAnalytics = typeof layoutAnalytics.$inferSelect;
-export type NewLayoutAnalytics = typeof layoutAnalytics.$inferInsert;
+export type LayoutAnalytics = InferSelectModel<typeof layoutAnalytics>;
+export type NewLayoutAnalytics = InferInsertModel<typeof layoutAnalytics>;
 
-export type UserLayoutPreference = typeof userLayoutPreferences.$inferSelect;
-export type NewUserLayoutPreference = typeof userLayoutPreferences.$inferInsert;
+export type UserLayoutPreference = InferSelectModel<typeof userLayoutPreferences>;
+export type NewUserLayoutPreference = InferInsertModel<typeof userLayoutPreferences>;
 
-export type LayoutAbTest = typeof layoutAbTests.$inferSelect;
-export type NewLayoutAbTest = typeof layoutAbTests.$inferInsert;
+export type LayoutAbTest = InferSelectModel<typeof layoutAbTests>;
+export type NewLayoutAbTest = InferInsertModel<typeof layoutAbTests>;
 
-export type LayoutPersonalization = typeof layoutPersonalization.$inferSelect;
-export type NewLayoutPersonalization = typeof layoutPersonalization.$inferInsert;
+export type LayoutPersonalization = InferSelectModel<typeof layoutPersonalization>;
+export type NewLayoutPersonalization = InferInsertModel<typeof layoutPersonalization>;
+
+// DTOs
+const layoutTemplateDTOKeys = ["id", "name", "category", "createdAt", "updatedAt", "description", "version"] as const;
+
+export interface LayoutTemplateDTO
+  extends Pick<LayoutTemplate, (typeof layoutTemplateDTOKeys)[number]> {}
+
+export const toLayoutTemplateDTO = (layoutTemplate: LayoutTemplate): LayoutTemplateDTO =>
+  pickDTOFields(layoutTemplate, layoutTemplateDTOKeys);
+
+
+const layoutInstanceDTOKeys = ["id", "sessionId", "userId"] as const;
+
+export interface LayoutInstanceDTO
+  extends Pick<LayoutInstance, (typeof layoutInstanceDTOKeys)[number]> {}
+
+export const toLayoutInstanceDTO = (layoutInstance: LayoutInstance): LayoutInstanceDTO =>
+  pickDTOFields(layoutInstance, layoutInstanceDTOKeys);
+
+
+const layoutMutationDTOKeys = ["id", "instanceId", "elementId"] as const;
+
+export interface LayoutMutationDTO
+  extends Pick<LayoutMutation, (typeof layoutMutationDTOKeys)[number]> {}
+
+export const toLayoutMutationDTO = (layoutMutation: LayoutMutation): LayoutMutationDTO =>
+  pickDTOFields(layoutMutation, layoutMutationDTOKeys);
+
+
+const layoutAnalyticsDTOKeys = ["id", "sessionId", "userId"] as const;
+
+export interface LayoutAnalyticsDTO
+  extends Pick<LayoutAnalytics, (typeof layoutAnalyticsDTOKeys)[number]> {}
+
+export const toLayoutAnalyticsDTO = (layoutAnalytics: LayoutAnalytics): LayoutAnalyticsDTO =>
+  pickDTOFields(layoutAnalytics, layoutAnalyticsDTOKeys);
+
+
+const userLayoutPreferenceDTOKeys = ["id", "userId", "createdAt", "updatedAt", "source"] as const;
+
+export interface UserLayoutPreferenceDTO
+  extends Pick<UserLayoutPreference, (typeof userLayoutPreferenceDTOKeys)[number]> {}
+
+export const toUserLayoutPreferenceDTO = (userLayoutPreference: UserLayoutPreference): UserLayoutPreferenceDTO =>
+  pickDTOFields(userLayoutPreference, userLayoutPreferenceDTOKeys);
+
+
+const layoutAbTestDTOKeys = ["id", "name", "status", "createdAt", "updatedAt", "description"] as const;
+
+export interface LayoutAbTestDTO
+  extends Pick<LayoutAbTest, (typeof layoutAbTestDTOKeys)[number]> {}
+
+export const toLayoutAbTestDTO = (layoutAbTest: LayoutAbTest): LayoutAbTestDTO =>
+  pickDTOFields(layoutAbTest, layoutAbTestDTOKeys);
+
+
+const layoutPersonalizationDTOKeys = ["id", "name", "priority", "createdAt", "updatedAt", "description"] as const;
+
+export interface LayoutPersonalizationDTO
+  extends Pick<LayoutPersonalization, (typeof layoutPersonalizationDTOKeys)[number]> {}
+
+export const toLayoutPersonalizationDTO = (layoutPersonalization: LayoutPersonalization): LayoutPersonalizationDTO =>
+  pickDTOFields(layoutPersonalization, layoutPersonalizationDTOKeys);
+

--- a/shared/moneyTrafficGrowthTables.ts
+++ b/shared/moneyTrafficGrowthTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // ===================================================================
 // MONEY/TRAFFIC GROWTH ENGINE TABLES - BILLION-DOLLAR EMPIRE GRADE
 // ===================================================================
@@ -504,27 +506,27 @@ export const insertConversionExperimentsSchema = createInsertSchema(conversionEx
 export const insertConversionEventsSchema = createInsertSchema(conversionEvents);
 
 // TypeScript types for all tables
-export type SeoOptimizationTask = typeof seoOptimizationTasks.$inferSelect;
-export type SeoKeywordResearch = typeof seoKeywordResearch.$inferSelect;
-export type SeoSiteAudit = typeof seoSiteAudits.$inferSelect;
-export type ContentTemplate = typeof contentTemplates.$inferSelect;
-export type ContentGeneration = typeof contentGeneration.$inferSelect;
-export type ContentPerformance = typeof contentPerformance.$inferSelect;
-export type ReferralProgram = typeof referralPrograms.$inferSelect;
-export type ReferralLink = typeof referralLinks.$inferSelect;
-export type ReferralTransaction = typeof referralTransactions.$inferSelect;
-export type BacklinkOpportunity = typeof backlinkOpportunities.$inferSelect;
-export type BacklinkOutreach = typeof backlinkOutreach.$inferSelect;
-export type BacklinkMonitoring = typeof backlinkMonitoring.$inferSelect;
-export type SocialMediaAccount = typeof socialMediaAccounts.$inferSelect;
-export type SocialMediaPost = typeof socialMediaPosts.$inferSelect;
-export type SocialMediaEngagement = typeof socialMediaEngagement.$inferSelect;
-export type EmailCampaign = typeof emailCampaigns.$inferSelect;
-export type EmailAutomation = typeof emailAutomations.$inferSelect;
-export type EmailSubscriber = typeof emailSubscribers.$inferSelect;
-export type ConversionFunnel = typeof conversionFunnels.$inferSelect;
-export type ConversionExperiment = typeof conversionExperiments.$inferSelect;
-export type ConversionEvent = typeof conversionEvents.$inferSelect;
+export type SeoOptimizationTask = InferSelectModel<typeof seoOptimizationTasks>;
+export type SeoKeywordResearch = InferSelectModel<typeof seoKeywordResearch>;
+export type SeoSiteAudit = InferSelectModel<typeof seoSiteAudits>;
+export type ContentTemplate = InferSelectModel<typeof contentTemplates>;
+export type ContentGeneration = InferSelectModel<typeof contentGeneration>;
+export type ContentPerformance = InferSelectModel<typeof contentPerformance>;
+export type ReferralProgram = InferSelectModel<typeof referralPrograms>;
+export type ReferralLink = InferSelectModel<typeof referralLinks>;
+export type ReferralTransaction = InferSelectModel<typeof referralTransactions>;
+export type BacklinkOpportunity = InferSelectModel<typeof backlinkOpportunities>;
+export type BacklinkOutreach = InferSelectModel<typeof backlinkOutreach>;
+export type BacklinkMonitoring = InferSelectModel<typeof backlinkMonitoring>;
+export type SocialMediaAccount = InferSelectModel<typeof socialMediaAccounts>;
+export type SocialMediaPost = InferSelectModel<typeof socialMediaPosts>;
+export type SocialMediaEngagement = InferSelectModel<typeof socialMediaEngagement>;
+export type EmailCampaign = InferSelectModel<typeof emailCampaigns>;
+export type EmailAutomation = InferSelectModel<typeof emailAutomations>;
+export type EmailSubscriber = InferSelectModel<typeof emailSubscribers>;
+export type ConversionFunnel = InferSelectModel<typeof conversionFunnels>;
+export type ConversionExperiment = InferSelectModel<typeof conversionExperiments>;
+export type ConversionEvent = InferSelectModel<typeof conversionEvents>;
 
 // ===================================================================
 // ADDITIONAL TRAFFIC GENERATION MODULES - BILLION-DOLLAR EMPIRE GRADE
@@ -1108,28 +1110,443 @@ export const insertPublicWidgetsSchema = createInsertSchema(publicWidgets);
 export const insertWidgetEmbedsSchema = createInsertSchema(widgetEmbeds);
 
 // TypeScript types for all new tables
-export type BlogSwarmSite = typeof blogSwarmSites.$inferSelect;
-export type BlogSwarmPost = typeof blogSwarmPosts.$inferSelect;
-export type BlogSwarmTrend = typeof blogSwarmTrends.$inferSelect;
-export type ForumCategory = typeof forumCategories.$inferSelect;
-export type ForumTopic = typeof forumTopics.$inferSelect;
-export type ForumReply = typeof forumReplies.$inferSelect;
-export type ResourceCategory = typeof resourceCategories.$inferSelect;
-export type ResourceDirectory = typeof resourceDirectory.$inferSelect;
-export type ResourceComparison = typeof resourceComparisons.$inferSelect;
-export type DataVisualizationProject = typeof dataVisualizationProjects.$inferSelect;
-export type DataVisualizationStats = typeof dataVisualizationStats.$inferSelect;
-export type NewsletterEdition = typeof newsletterEditions.$inferSelect;
-export type NewsletterSubscriber = typeof newsletterSubscribers.$inferSelect;
-export type UgcVideoSubmission = typeof ugcVideoSubmissions.$inferSelect;
-export type UgcVideoContest = typeof ugcVideoContests.$inferSelect;
-export type ViralChallenge = typeof viralChallenges.$inferSelect;
-export type ChallengeParticipant = typeof challengeParticipants.$inferSelect;
-export type ContentScrapingSource = typeof contentScrapingSources.$inferSelect;
-export type ScrapedContent = typeof scrapedContent.$inferSelect;
-export type ContentRemixProject = typeof contentRemixProjects.$inferSelect;
-export type ContentRemixDistribution = typeof contentRemixDistribution.$inferSelect;
-export type PublicApiEndpoint = typeof publicApiEndpoints.$inferSelect;
-export type PublicApiKey = typeof publicApiKeys.$inferSelect;
-export type PublicWidget = typeof publicWidgets.$inferSelect;
-export type WidgetEmbed = typeof widgetEmbeds.$inferSelect;
+export type BlogSwarmSite = InferSelectModel<typeof blogSwarmSites>;
+export type BlogSwarmPost = InferSelectModel<typeof blogSwarmPosts>;
+export type BlogSwarmTrend = InferSelectModel<typeof blogSwarmTrends>;
+export type ForumCategory = InferSelectModel<typeof forumCategories>;
+export type ForumTopic = InferSelectModel<typeof forumTopics>;
+export type ForumReply = InferSelectModel<typeof forumReplies>;
+export type ResourceCategory = InferSelectModel<typeof resourceCategories>;
+export type ResourceDirectory = InferSelectModel<typeof resourceDirectory>;
+export type ResourceComparison = InferSelectModel<typeof resourceComparisons>;
+export type DataVisualizationProject = InferSelectModel<typeof dataVisualizationProjects>;
+export type DataVisualizationStats = InferSelectModel<typeof dataVisualizationStats>;
+export type NewsletterEdition = InferSelectModel<typeof newsletterEditions>;
+export type NewsletterSubscriber = InferSelectModel<typeof newsletterSubscribers>;
+export type UgcVideoSubmission = InferSelectModel<typeof ugcVideoSubmissions>;
+export type UgcVideoContest = InferSelectModel<typeof ugcVideoContests>;
+export type ViralChallenge = InferSelectModel<typeof viralChallenges>;
+export type ChallengeParticipant = InferSelectModel<typeof challengeParticipants>;
+export type ContentScrapingSource = InferSelectModel<typeof contentScrapingSources>;
+export type ScrapedContent = InferSelectModel<typeof scrapedContent>;
+export type ContentRemixProject = InferSelectModel<typeof contentRemixProjects>;
+export type ContentRemixDistribution = InferSelectModel<typeof contentRemixDistribution>;
+export type PublicApiEndpoint = InferSelectModel<typeof publicApiEndpoints>;
+export type PublicApiKey = InferSelectModel<typeof publicApiKeys>;
+export type PublicWidget = InferSelectModel<typeof publicWidgets>;
+export type WidgetEmbed = InferSelectModel<typeof widgetEmbeds>;
+
+// DTOs
+const seoOptimizationTaskDTOKeys = ["id", "title", "status", "priority", "createdAt", "updatedAt"] as const;
+
+export interface SeoOptimizationTaskDTO
+  extends Pick<SeoOptimizationTask, (typeof seoOptimizationTaskDTOKeys)[number]> {}
+
+export const toSeoOptimizationTaskDTO = (seoOptimizationTask: SeoOptimizationTask): SeoOptimizationTaskDTO =>
+  pickDTOFields(seoOptimizationTask, seoOptimizationTaskDTOKeys);
+
+
+const seoKeywordResearchDTOKeys = ["id", "vertical", "priority", "createdAt"] as const;
+
+export interface SeoKeywordResearchDTO
+  extends Pick<SeoKeywordResearch, (typeof seoKeywordResearchDTOKeys)[number]> {}
+
+export const toSeoKeywordResearchDTO = (seoKeywordResearch: SeoKeywordResearch): SeoKeywordResearchDTO =>
+  pickDTOFields(seoKeywordResearch, seoKeywordResearchDTOKeys);
+
+
+const seoSiteAuditDTOKeys = ["id", "createdAt", "domain"] as const;
+
+export interface SeoSiteAuditDTO
+  extends Pick<SeoSiteAudit, (typeof seoSiteAuditDTOKeys)[number]> {}
+
+export const toSeoSiteAuditDTO = (seoSiteAudit: SeoSiteAudit): SeoSiteAuditDTO =>
+  pickDTOFields(seoSiteAudit, seoSiteAuditDTOKeys);
+
+
+const contentTemplateDTOKeys = ["id", "name", "vertical", "createdAt", "updatedAt"] as const;
+
+export interface ContentTemplateDTO
+  extends Pick<ContentTemplate, (typeof contentTemplateDTOKeys)[number]> {}
+
+export const toContentTemplateDTO = (contentTemplate: ContentTemplate): ContentTemplateDTO =>
+  pickDTOFields(contentTemplate, contentTemplateDTOKeys);
+
+
+const contentGenerationDTOKeys = ["id", "title", "status", "vertical", "createdAt", "updatedAt"] as const;
+
+export interface ContentGenerationDTO
+  extends Pick<ContentGeneration, (typeof contentGenerationDTOKeys)[number]> {}
+
+export const toContentGenerationDTO = (contentGeneration: ContentGeneration): ContentGenerationDTO =>
+  pickDTOFields(contentGeneration, contentGenerationDTOKeys);
+
+
+const contentPerformanceDTOKeys = ["id", "createdAt", "contentId"] as const;
+
+export interface ContentPerformanceDTO
+  extends Pick<ContentPerformance, (typeof contentPerformanceDTOKeys)[number]> {}
+
+export const toContentPerformanceDTO = (contentPerformance: ContentPerformance): ContentPerformanceDTO =>
+  pickDTOFields(contentPerformance, contentPerformanceDTOKeys);
+
+
+const referralProgramDTOKeys = ["id", "name", "vertical", "createdAt", "updatedAt", "description"] as const;
+
+export interface ReferralProgramDTO
+  extends Pick<ReferralProgram, (typeof referralProgramDTOKeys)[number]> {}
+
+export const toReferralProgramDTO = (referralProgram: ReferralProgram): ReferralProgramDTO =>
+  pickDTOFields(referralProgram, referralProgramDTOKeys);
+
+
+const referralLinkDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface ReferralLinkDTO
+  extends Pick<ReferralLink, (typeof referralLinkDTOKeys)[number]> {}
+
+export const toReferralLinkDTO = (referralLink: ReferralLink): ReferralLinkDTO =>
+  pickDTOFields(referralLink, referralLinkDTOKeys);
+
+
+const referralTransactionDTOKeys = ["id", "status", "createdAt"] as const;
+
+export interface ReferralTransactionDTO
+  extends Pick<ReferralTransaction, (typeof referralTransactionDTOKeys)[number]> {}
+
+export const toReferralTransactionDTO = (referralTransaction: ReferralTransaction): ReferralTransactionDTO =>
+  pickDTOFields(referralTransaction, referralTransactionDTOKeys);
+
+
+const backlinkOpportunityDTOKeys = ["id", "vertical", "priority", "createdAt", "updatedAt"] as const;
+
+export interface BacklinkOpportunityDTO
+  extends Pick<BacklinkOpportunity, (typeof backlinkOpportunityDTOKeys)[number]> {}
+
+export const toBacklinkOpportunityDTO = (backlinkOpportunity: BacklinkOpportunity): BacklinkOpportunityDTO =>
+  pickDTOFields(backlinkOpportunity, backlinkOpportunityDTOKeys);
+
+
+const backlinkOutreachDTOKeys = ["id", "createdAt", "opportunityId"] as const;
+
+export interface BacklinkOutreachDTO
+  extends Pick<BacklinkOutreach, (typeof backlinkOutreachDTOKeys)[number]> {}
+
+export const toBacklinkOutreachDTO = (backlinkOutreach: BacklinkOutreach): BacklinkOutreachDTO =>
+  pickDTOFields(backlinkOutreach, backlinkOutreachDTOKeys);
+
+
+const backlinkMonitoringDTOKeys = ["id", "createdAt", "sourceUrl"] as const;
+
+export interface BacklinkMonitoringDTO
+  extends Pick<BacklinkMonitoring, (typeof backlinkMonitoringDTOKeys)[number]> {}
+
+export const toBacklinkMonitoringDTO = (backlinkMonitoring: BacklinkMonitoring): BacklinkMonitoringDTO =>
+  pickDTOFields(backlinkMonitoring, backlinkMonitoringDTOKeys);
+
+
+const socialMediaAccountDTOKeys = ["id", "vertical", "createdAt", "updatedAt"] as const;
+
+export interface SocialMediaAccountDTO
+  extends Pick<SocialMediaAccount, (typeof socialMediaAccountDTOKeys)[number]> {}
+
+export const toSocialMediaAccountDTO = (socialMediaAccount: SocialMediaAccount): SocialMediaAccountDTO =>
+  pickDTOFields(socialMediaAccount, socialMediaAccountDTOKeys);
+
+
+const socialMediaPostDTOKeys = ["id", "status", "createdAt", "updatedAt"] as const;
+
+export interface SocialMediaPostDTO
+  extends Pick<SocialMediaPost, (typeof socialMediaPostDTOKeys)[number]> {}
+
+export const toSocialMediaPostDTO = (socialMediaPost: SocialMediaPost): SocialMediaPostDTO =>
+  pickDTOFields(socialMediaPost, socialMediaPostDTOKeys);
+
+
+const socialMediaEngagementDTOKeys = ["id", "userId", "createdAt"] as const;
+
+export interface SocialMediaEngagementDTO
+  extends Pick<SocialMediaEngagement, (typeof socialMediaEngagementDTOKeys)[number]> {}
+
+export const toSocialMediaEngagementDTO = (socialMediaEngagement: SocialMediaEngagement): SocialMediaEngagementDTO =>
+  pickDTOFields(socialMediaEngagement, socialMediaEngagementDTOKeys);
+
+
+const emailCampaignDTOKeys = ["id", "name", "status", "vertical", "createdAt", "updatedAt"] as const;
+
+export interface EmailCampaignDTO
+  extends Pick<EmailCampaign, (typeof emailCampaignDTOKeys)[number]> {}
+
+export const toEmailCampaignDTO = (emailCampaign: EmailCampaign): EmailCampaignDTO =>
+  pickDTOFields(emailCampaign, emailCampaignDTOKeys);
+
+
+const emailAutomationDTOKeys = ["id", "name", "vertical", "createdAt", "updatedAt"] as const;
+
+export interface EmailAutomationDTO
+  extends Pick<EmailAutomation, (typeof emailAutomationDTOKeys)[number]> {}
+
+export const toEmailAutomationDTO = (emailAutomation: EmailAutomation): EmailAutomationDTO =>
+  pickDTOFields(emailAutomation, emailAutomationDTOKeys);
+
+
+const emailSubscriberDTOKeys = ["id", "status", "vertical", "createdAt", "updatedAt", "email"] as const;
+
+export interface EmailSubscriberDTO
+  extends Pick<EmailSubscriber, (typeof emailSubscriberDTOKeys)[number]> {}
+
+export const toEmailSubscriberDTO = (emailSubscriber: EmailSubscriber): EmailSubscriberDTO =>
+  pickDTOFields(emailSubscriber, emailSubscriberDTOKeys);
+
+
+const conversionFunnelDTOKeys = ["id", "name", "vertical", "createdAt", "updatedAt"] as const;
+
+export interface ConversionFunnelDTO
+  extends Pick<ConversionFunnel, (typeof conversionFunnelDTOKeys)[number]> {}
+
+export const toConversionFunnelDTO = (conversionFunnel: ConversionFunnel): ConversionFunnelDTO =>
+  pickDTOFields(conversionFunnel, conversionFunnelDTOKeys);
+
+
+const conversionExperimentDTOKeys = ["id", "status", "createdAt", "updatedAt", "funnelId"] as const;
+
+export interface ConversionExperimentDTO
+  extends Pick<ConversionExperiment, (typeof conversionExperimentDTOKeys)[number]> {}
+
+export const toConversionExperimentDTO = (conversionExperiment: ConversionExperiment): ConversionExperimentDTO =>
+  pickDTOFields(conversionExperiment, conversionExperimentDTOKeys);
+
+
+const conversionEventDTOKeys = ["id", "sessionId", "userId", "createdAt", "eventType", "funnelId"] as const;
+
+export interface ConversionEventDTO
+  extends Pick<ConversionEvent, (typeof conversionEventDTOKeys)[number]> {}
+
+export const toConversionEventDTO = (conversionEvent: ConversionEvent): ConversionEventDTO =>
+  pickDTOFields(conversionEvent, conversionEventDTOKeys);
+
+
+const blogSwarmSiteDTOKeys = ["id", "status", "vertical", "createdAt"] as const;
+
+export interface BlogSwarmSiteDTO
+  extends Pick<BlogSwarmSite, (typeof blogSwarmSiteDTOKeys)[number]> {}
+
+export const toBlogSwarmSiteDTO = (blogSwarmSite: BlogSwarmSite): BlogSwarmSiteDTO =>
+  pickDTOFields(blogSwarmSite, blogSwarmSiteDTOKeys);
+
+
+const blogSwarmPostDTOKeys = ["id", "title", "slug", "status", "createdAt"] as const;
+
+export interface BlogSwarmPostDTO
+  extends Pick<BlogSwarmPost, (typeof blogSwarmPostDTOKeys)[number]> {}
+
+export const toBlogSwarmPostDTO = (blogSwarmPost: BlogSwarmPost): BlogSwarmPostDTO =>
+  pickDTOFields(blogSwarmPost, blogSwarmPostDTOKeys);
+
+
+const blogSwarmTrendDTOKeys = ["id", "vertical", "createdAt"] as const;
+
+export interface BlogSwarmTrendDTO
+  extends Pick<BlogSwarmTrend, (typeof blogSwarmTrendDTOKeys)[number]> {}
+
+export const toBlogSwarmTrendDTO = (blogSwarmTrend: BlogSwarmTrend): BlogSwarmTrendDTO =>
+  pickDTOFields(blogSwarmTrend, blogSwarmTrendDTOKeys);
+
+
+const forumCategoryDTOKeys = ["id", "name", "slug", "vertical", "createdAt", "description"] as const;
+
+export interface ForumCategoryDTO
+  extends Pick<ForumCategory, (typeof forumCategoryDTOKeys)[number]> {}
+
+export const toForumCategoryDTO = (forumCategory: ForumCategory): ForumCategoryDTO =>
+  pickDTOFields(forumCategory, forumCategoryDTOKeys);
+
+
+const forumTopicDTOKeys = ["id", "title", "slug", "createdAt", "updatedAt"] as const;
+
+export interface ForumTopicDTO
+  extends Pick<ForumTopic, (typeof forumTopicDTOKeys)[number]> {}
+
+export const toForumTopicDTO = (forumTopic: ForumTopic): ForumTopicDTO =>
+  pickDTOFields(forumTopic, forumTopicDTOKeys);
+
+
+const forumReplyDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface ForumReplyDTO
+  extends Pick<ForumReply, (typeof forumReplyDTOKeys)[number]> {}
+
+export const toForumReplyDTO = (forumReply: ForumReply): ForumReplyDTO =>
+  pickDTOFields(forumReply, forumReplyDTOKeys);
+
+
+const resourceCategoryDTOKeys = ["id", "name", "slug", "vertical", "createdAt", "description"] as const;
+
+export interface ResourceCategoryDTO
+  extends Pick<ResourceCategory, (typeof resourceCategoryDTOKeys)[number]> {}
+
+export const toResourceCategoryDTO = (resourceCategory: ResourceCategory): ResourceCategoryDTO =>
+  pickDTOFields(resourceCategory, resourceCategoryDTOKeys);
+
+
+const resourceDirectoryDTOKeys = ["id", "name", "slug", "createdAt", "description"] as const;
+
+export interface ResourceDirectoryDTO
+  extends Pick<ResourceDirectory, (typeof resourceDirectoryDTOKeys)[number]> {}
+
+export const toResourceDirectoryDTO = (resourceDirectory: ResourceDirectory): ResourceDirectoryDTO =>
+  pickDTOFields(resourceDirectory, resourceDirectoryDTOKeys);
+
+
+const resourceComparisonDTOKeys = ["id", "title", "slug", "vertical", "createdAt", "description"] as const;
+
+export interface ResourceComparisonDTO
+  extends Pick<ResourceComparison, (typeof resourceComparisonDTOKeys)[number]> {}
+
+export const toResourceComparisonDTO = (resourceComparison: ResourceComparison): ResourceComparisonDTO =>
+  pickDTOFields(resourceComparison, resourceComparisonDTOKeys);
+
+
+const dataVisualizationProjectDTOKeys = ["id", "title", "slug", "vertical", "createdAt", "updatedAt", "description"] as const;
+
+export interface DataVisualizationProjectDTO
+  extends Pick<DataVisualizationProject, (typeof dataVisualizationProjectDTOKeys)[number]> {}
+
+export const toDataVisualizationProjectDTO = (dataVisualizationProject: DataVisualizationProject): DataVisualizationProjectDTO =>
+  pickDTOFields(dataVisualizationProject, dataVisualizationProjectDTOKeys);
+
+
+const dataVisualizationStatsDTOKeys = ["id", "createdAt", "projectId"] as const;
+
+export interface DataVisualizationStatsDTO
+  extends Pick<DataVisualizationStats, (typeof dataVisualizationStatsDTOKeys)[number]> {}
+
+export const toDataVisualizationStatsDTO = (dataVisualizationStats: DataVisualizationStats): DataVisualizationStatsDTO =>
+  pickDTOFields(dataVisualizationStats, dataVisualizationStatsDTOKeys);
+
+
+const newsletterEditionDTOKeys = ["id", "title", "status", "vertical", "createdAt"] as const;
+
+export interface NewsletterEditionDTO
+  extends Pick<NewsletterEdition, (typeof newsletterEditionDTOKeys)[number]> {}
+
+export const toNewsletterEditionDTO = (newsletterEdition: NewsletterEdition): NewsletterEditionDTO =>
+  pickDTOFields(newsletterEdition, newsletterEditionDTOKeys);
+
+
+const newsletterSubscriberDTOKeys = ["id", "vertical", "createdAt", "email"] as const;
+
+export interface NewsletterSubscriberDTO
+  extends Pick<NewsletterSubscriber, (typeof newsletterSubscriberDTOKeys)[number]> {}
+
+export const toNewsletterSubscriberDTO = (newsletterSubscriber: NewsletterSubscriber): NewsletterSubscriberDTO =>
+  pickDTOFields(newsletterSubscriber, newsletterSubscriberDTOKeys);
+
+
+const ugcVideoSubmissionDTOKeys = ["id", "title", "vertical", "createdAt", "description"] as const;
+
+export interface UgcVideoSubmissionDTO
+  extends Pick<UgcVideoSubmission, (typeof ugcVideoSubmissionDTOKeys)[number]> {}
+
+export const toUgcVideoSubmissionDTO = (ugcVideoSubmission: UgcVideoSubmission): UgcVideoSubmissionDTO =>
+  pickDTOFields(ugcVideoSubmission, ugcVideoSubmissionDTOKeys);
+
+
+const ugcVideoContestDTOKeys = ["id", "title", "vertical", "createdAt", "description"] as const;
+
+export interface UgcVideoContestDTO
+  extends Pick<UgcVideoContest, (typeof ugcVideoContestDTOKeys)[number]> {}
+
+export const toUgcVideoContestDTO = (ugcVideoContest: UgcVideoContest): UgcVideoContestDTO =>
+  pickDTOFields(ugcVideoContest, ugcVideoContestDTOKeys);
+
+
+const viralChallengeDTOKeys = ["id", "title", "vertical", "createdAt", "description"] as const;
+
+export interface ViralChallengeDTO
+  extends Pick<ViralChallenge, (typeof viralChallengeDTOKeys)[number]> {}
+
+export const toViralChallengeDTO = (viralChallenge: ViralChallenge): ViralChallengeDTO =>
+  pickDTOFields(viralChallenge, viralChallengeDTOKeys);
+
+
+const challengeParticipantDTOKeys = ["id", "userId", "createdAt", "updatedAt"] as const;
+
+export interface ChallengeParticipantDTO
+  extends Pick<ChallengeParticipant, (typeof challengeParticipantDTOKeys)[number]> {}
+
+export const toChallengeParticipantDTO = (challengeParticipant: ChallengeParticipant): ChallengeParticipantDTO =>
+  pickDTOFields(challengeParticipant, challengeParticipantDTOKeys);
+
+
+const contentScrapingSourceDTOKeys = ["id", "name", "vertical", "createdAt"] as const;
+
+export interface ContentScrapingSourceDTO
+  extends Pick<ContentScrapingSource, (typeof contentScrapingSourceDTOKeys)[number]> {}
+
+export const toContentScrapingSourceDTO = (contentScrapingSource: ContentScrapingSource): ContentScrapingSourceDTO =>
+  pickDTOFields(contentScrapingSource, contentScrapingSourceDTOKeys);
+
+
+const scrapedContentDTOKeys = ["id", "title", "language", "createdAt", "summary"] as const;
+
+export interface ScrapedContentDTO
+  extends Pick<ScrapedContent, (typeof scrapedContentDTOKeys)[number]> {}
+
+export const toScrapedContentDTO = (scrapedContent: ScrapedContent): ScrapedContentDTO =>
+  pickDTOFields(scrapedContent, scrapedContentDTOKeys);
+
+
+const contentRemixProjectDTOKeys = ["id", "vertical", "createdAt"] as const;
+
+export interface ContentRemixProjectDTO
+  extends Pick<ContentRemixProject, (typeof contentRemixProjectDTOKeys)[number]> {}
+
+export const toContentRemixProjectDTO = (contentRemixProject: ContentRemixProject): ContentRemixProjectDTO =>
+  pickDTOFields(contentRemixProject, contentRemixProjectDTOKeys);
+
+
+const contentRemixDistributionDTOKeys = ["id", "status", "createdAt"] as const;
+
+export interface ContentRemixDistributionDTO
+  extends Pick<ContentRemixDistribution, (typeof contentRemixDistributionDTOKeys)[number]> {}
+
+export const toContentRemixDistributionDTO = (contentRemixDistribution: ContentRemixDistribution): ContentRemixDistributionDTO =>
+  pickDTOFields(contentRemixDistribution, contentRemixDistributionDTOKeys);
+
+
+const publicApiEndpointDTOKeys = ["id", "name", "category", "createdAt", "description"] as const;
+
+export interface PublicApiEndpointDTO
+  extends Pick<PublicApiEndpoint, (typeof publicApiEndpointDTOKeys)[number]> {}
+
+export const toPublicApiEndpointDTO = (publicApiEndpoint: PublicApiEndpoint): PublicApiEndpointDTO =>
+  pickDTOFields(publicApiEndpoint, publicApiEndpointDTOKeys);
+
+
+const publicApiKeyDTOKeys = ["id", "userId", "createdAt"] as const;
+
+export interface PublicApiKeyDTO
+  extends Pick<PublicApiKey, (typeof publicApiKeyDTOKeys)[number]> {}
+
+export const toPublicApiKeyDTO = (publicApiKey: PublicApiKey): PublicApiKeyDTO =>
+  pickDTOFields(publicApiKey, publicApiKeyDTOKeys);
+
+
+const publicWidgetDTOKeys = ["id", "name", "category", "createdAt", "description"] as const;
+
+export interface PublicWidgetDTO
+  extends Pick<PublicWidget, (typeof publicWidgetDTOKeys)[number]> {}
+
+export const toPublicWidgetDTO = (publicWidget: PublicWidget): PublicWidgetDTO =>
+  pickDTOFields(publicWidget, publicWidgetDTOKeys);
+
+
+const widgetEmbedDTOKeys = ["id", "createdAt", "widgetId"] as const;
+
+export interface WidgetEmbedDTO
+  extends Pick<WidgetEmbed, (typeof widgetEmbedDTOKeys)[number]> {}
+
+export const toWidgetEmbedDTO = (widgetEmbed: WidgetEmbed): WidgetEmbedDTO =>
+  pickDTOFields(widgetEmbed, widgetEmbedDTOKeys);
+

--- a/shared/multiRegionTables.ts
+++ b/shared/multiRegionTables.ts
@@ -1,3 +1,5 @@
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 /**
  * Multi-Region Load Orchestrator Database Schema
  * Enterprise-grade tables for global load balancing and failover management
@@ -224,3 +226,104 @@ export const disasterRecoveryScenarios = pgTable('disaster_recovery_scenarios', 
   created_at: timestamp('created_at').defaultNow().notNull(),
   updated_at: timestamp('updated_at').defaultNow().notNull()
 });
+
+export type MultiRegionRegion = InferSelectModel<typeof regions>;
+export type InsertMultiRegionRegion = InferInsertModel<typeof regions>;
+export type MultiRegionRegionHealth = InferSelectModel<typeof regionHealth>;
+export type InsertMultiRegionRegionHealth = InferInsertModel<typeof regionHealth>;
+export type MultiRegionLoadBalancingRule = InferSelectModel<typeof loadBalancingRules>;
+export type InsertMultiRegionLoadBalancingRule = InferInsertModel<typeof loadBalancingRules>;
+export type MultiRegionTrafficDistribution = InferSelectModel<typeof trafficDistribution>;
+export type InsertMultiRegionTrafficDistribution = InferInsertModel<typeof trafficDistribution>;
+export type MultiRegionFailoverEvent = InferSelectModel<typeof failoverEvents>;
+export type InsertMultiRegionFailoverEvent = InferInsertModel<typeof failoverEvents>;
+export type MultiRegionRoutingDecision = InferSelectModel<typeof routingDecisions>;
+export type InsertMultiRegionRoutingDecision = InferInsertModel<typeof routingDecisions>;
+export type MultiRegionAutoScalingEvent = InferSelectModel<typeof autoScalingEvents>;
+export type InsertMultiRegionAutoScalingEvent = InferInsertModel<typeof autoScalingEvents>;
+export type MultiRegionGlobalPerformanceMetric = InferSelectModel<typeof globalPerformanceMetrics>;
+export type InsertMultiRegionGlobalPerformanceMetric = InferInsertModel<typeof globalPerformanceMetrics>;
+export type MultiRegionDisasterRecoveryScenario = InferSelectModel<typeof disasterRecoveryScenarios>;
+export type InsertMultiRegionDisasterRecoveryScenario = InferInsertModel<typeof disasterRecoveryScenarios>;
+
+// DTOs
+const multiRegionRegionDTOKeys = ["id", "name", "status"] as const;
+
+export interface MultiRegionRegionDTO
+  extends Pick<MultiRegionRegion, (typeof multiRegionRegionDTOKeys)[number]> {}
+
+export const toMultiRegionRegionDTO = (multiRegionRegion: MultiRegionRegion): MultiRegionRegionDTO =>
+  pickDTOFields(multiRegionRegion, multiRegionRegionDTOKeys);
+
+
+const multiRegionRegionHealthDTOKeys = ["id", "status", "region_id"] as const;
+
+export interface MultiRegionRegionHealthDTO
+  extends Pick<MultiRegionRegionHealth, (typeof multiRegionRegionHealthDTOKeys)[number]> {}
+
+export const toMultiRegionRegionHealthDTO = (multiRegionRegionHealth: MultiRegionRegionHealth): MultiRegionRegionHealthDTO =>
+  pickDTOFields(multiRegionRegionHealth, multiRegionRegionHealthDTOKeys);
+
+
+const multiRegionLoadBalancingRuleDTOKeys = ["id", "name", "type", "priority"] as const;
+
+export interface MultiRegionLoadBalancingRuleDTO
+  extends Pick<MultiRegionLoadBalancingRule, (typeof multiRegionLoadBalancingRuleDTOKeys)[number]> {}
+
+export const toMultiRegionLoadBalancingRuleDTO = (multiRegionLoadBalancingRule: MultiRegionLoadBalancingRule): MultiRegionLoadBalancingRuleDTO =>
+  pickDTOFields(multiRegionLoadBalancingRule, multiRegionLoadBalancingRuleDTOKeys);
+
+
+const multiRegionTrafficDistributionDTOKeys = ["id", "timestamp", "total_requests"] as const;
+
+export interface MultiRegionTrafficDistributionDTO
+  extends Pick<MultiRegionTrafficDistribution, (typeof multiRegionTrafficDistributionDTOKeys)[number]> {}
+
+export const toMultiRegionTrafficDistributionDTO = (multiRegionTrafficDistribution: MultiRegionTrafficDistribution): MultiRegionTrafficDistributionDTO =>
+  pickDTOFields(multiRegionTrafficDistribution, multiRegionTrafficDistributionDTOKeys);
+
+
+const multiRegionFailoverEventDTOKeys = ["id", "event_type", "trigger_reason"] as const;
+
+export interface MultiRegionFailoverEventDTO
+  extends Pick<MultiRegionFailoverEvent, (typeof multiRegionFailoverEventDTOKeys)[number]> {}
+
+export const toMultiRegionFailoverEventDTO = (multiRegionFailoverEvent: MultiRegionFailoverEvent): MultiRegionFailoverEventDTO =>
+  pickDTOFields(multiRegionFailoverEvent, multiRegionFailoverEventDTOKeys);
+
+
+const multiRegionRoutingDecisionDTOKeys = ["id", "user_id", "session_id"] as const;
+
+export interface MultiRegionRoutingDecisionDTO
+  extends Pick<MultiRegionRoutingDecision, (typeof multiRegionRoutingDecisionDTOKeys)[number]> {}
+
+export const toMultiRegionRoutingDecisionDTO = (multiRegionRoutingDecision: MultiRegionRoutingDecision): MultiRegionRoutingDecisionDTO =>
+  pickDTOFields(multiRegionRoutingDecision, multiRegionRoutingDecisionDTOKeys);
+
+
+const multiRegionAutoScalingEventDTOKeys = ["id", "region_id", "scaling_action"] as const;
+
+export interface MultiRegionAutoScalingEventDTO
+  extends Pick<MultiRegionAutoScalingEvent, (typeof multiRegionAutoScalingEventDTOKeys)[number]> {}
+
+export const toMultiRegionAutoScalingEventDTO = (multiRegionAutoScalingEvent: MultiRegionAutoScalingEvent): MultiRegionAutoScalingEventDTO =>
+  pickDTOFields(multiRegionAutoScalingEvent, multiRegionAutoScalingEventDTOKeys);
+
+
+const multiRegionGlobalPerformanceMetricDTOKeys = ["id", "timestamp", "metric_type"] as const;
+
+export interface MultiRegionGlobalPerformanceMetricDTO
+  extends Pick<MultiRegionGlobalPerformanceMetric, (typeof multiRegionGlobalPerformanceMetricDTOKeys)[number]> {}
+
+export const toMultiRegionGlobalPerformanceMetricDTO = (multiRegionGlobalPerformanceMetric: MultiRegionGlobalPerformanceMetric): MultiRegionGlobalPerformanceMetricDTO =>
+  pickDTOFields(multiRegionGlobalPerformanceMetric, multiRegionGlobalPerformanceMetricDTOKeys);
+
+
+const multiRegionDisasterRecoveryScenarioDTOKeys = ["id", "scenario_name", "scenario_type"] as const;
+
+export interface MultiRegionDisasterRecoveryScenarioDTO
+  extends Pick<MultiRegionDisasterRecoveryScenario, (typeof multiRegionDisasterRecoveryScenarioDTOKeys)[number]> {}
+
+export const toMultiRegionDisasterRecoveryScenarioDTO = (multiRegionDisasterRecoveryScenario: MultiRegionDisasterRecoveryScenario): MultiRegionDisasterRecoveryScenarioDTO =>
+  pickDTOFields(multiRegionDisasterRecoveryScenario, multiRegionDisasterRecoveryScenarioDTOKeys);
+

--- a/shared/notificationTables.ts
+++ b/shared/notificationTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // Notification Templates - Core templates for all channels
 export const notificationTemplates = pgTable("notification_templates", {
   id: serial("id").primaryKey(),
@@ -357,22 +359,86 @@ export const insertNotificationChannelSchema = createInsertSchema(notificationCh
 });
 
 // Type exports
-export type NotificationTemplate = typeof notificationTemplates.$inferSelect;
-export type InsertNotificationTemplate = z.infer<typeof insertNotificationTemplateSchema>;
+export type NotificationTemplate = InferSelectModel<typeof notificationTemplates>;
+export type InsertNotificationTemplate = InferInsertModel<typeof notificationTemplates>;
 
-export type NotificationTrigger = typeof notificationTriggers.$inferSelect;
-export type InsertNotificationTrigger = z.infer<typeof insertNotificationTriggerSchema>;
+export type NotificationTrigger = InferSelectModel<typeof notificationTriggers>;
+export type InsertNotificationTrigger = InferInsertModel<typeof notificationTriggers>;
 
-export type NotificationCampaign = typeof notificationCampaigns.$inferSelect;
-export type InsertNotificationCampaign = z.infer<typeof insertNotificationCampaignSchema>;
+export type NotificationCampaign = InferSelectModel<typeof notificationCampaigns>;
+export type InsertNotificationCampaign = InferInsertModel<typeof notificationCampaigns>;
 
-export type NotificationQueue = typeof notificationQueue.$inferSelect;
-export type InsertNotificationQueue = z.infer<typeof insertNotificationQueueSchema>;
+export type NotificationQueue = InferSelectModel<typeof notificationQueue>;
+export type InsertNotificationQueue = InferInsertModel<typeof notificationQueue>;
 
-export type UserNotificationPreferences = typeof userNotificationPreferences.$inferSelect;
-export type InsertUserNotificationPreferences = z.infer<typeof insertUserNotificationPreferencesSchema>;
+export type UserNotificationPreferences = InferSelectModel<typeof userNotificationPreferences>;
+export type InsertUserNotificationPreferences = InferInsertModel<typeof userNotificationPreferences>;
 
-export type NotificationChannel = typeof notificationChannels.$inferSelect;
-export type InsertNotificationChannel = z.infer<typeof insertNotificationChannelSchema>;
+export type NotificationChannel = InferSelectModel<typeof notificationChannels>;
+export type InsertNotificationChannel = InferInsertModel<typeof notificationChannels>;
 
-export type NotificationAnalytics = typeof notificationAnalytics.$inferSelect;
+export type NotificationAnalytics = InferSelectModel<typeof notificationAnalytics>;
+
+// DTOs
+const notificationTemplateDTOKeys = ["id", "name", "slug", "type", "locale", "segment", "channel", "priority", "createdAt", "updatedAt"] as const;
+
+export interface NotificationTemplateDTO
+  extends Pick<NotificationTemplate, (typeof notificationTemplateDTOKeys)[number]> {}
+
+export const toNotificationTemplateDTO = (notificationTemplate: NotificationTemplate): NotificationTemplateDTO =>
+  pickDTOFields(notificationTemplate, notificationTemplateDTOKeys);
+
+
+const notificationTriggerDTOKeys = ["id", "name", "slug", "priority", "createdAt", "updatedAt", "description"] as const;
+
+export interface NotificationTriggerDTO
+  extends Pick<NotificationTrigger, (typeof notificationTriggerDTOKeys)[number]> {}
+
+export const toNotificationTriggerDTO = (notificationTrigger: NotificationTrigger): NotificationTriggerDTO =>
+  pickDTOFields(notificationTrigger, notificationTriggerDTOKeys);
+
+
+const notificationCampaignDTOKeys = ["id", "name", "slug", "status", "type", "createdAt", "updatedAt", "description"] as const;
+
+export interface NotificationCampaignDTO
+  extends Pick<NotificationCampaign, (typeof notificationCampaignDTOKeys)[number]> {}
+
+export const toNotificationCampaignDTO = (notificationCampaign: NotificationCampaign): NotificationCampaignDTO =>
+  pickDTOFields(notificationCampaign, notificationCampaignDTOKeys);
+
+
+const notificationQueueDTOKeys = ["id", "status", "sessionId", "userId", "campaignId", "channel", "priority", "createdAt", "updatedAt"] as const;
+
+export interface NotificationQueueDTO
+  extends Pick<NotificationQueue, (typeof notificationQueueDTOKeys)[number]> {}
+
+export const toNotificationQueueDTO = (notificationQueue: NotificationQueue): NotificationQueueDTO =>
+  pickDTOFields(notificationQueue, notificationQueueDTOKeys);
+
+
+const userNotificationPreferencesDTOKeys = ["id", "sessionId", "userId", "createdAt", "updatedAt", "email"] as const;
+
+export interface UserNotificationPreferencesDTO
+  extends Pick<UserNotificationPreferences, (typeof userNotificationPreferencesDTOKeys)[number]> {}
+
+export const toUserNotificationPreferencesDTO = (userNotificationPreferences: UserNotificationPreferences): UserNotificationPreferencesDTO =>
+  pickDTOFields(userNotificationPreferences, userNotificationPreferencesDTOKeys);
+
+
+const notificationChannelDTOKeys = ["id", "channel", "priority", "createdAt", "updatedAt", "provider"] as const;
+
+export interface NotificationChannelDTO
+  extends Pick<NotificationChannel, (typeof notificationChannelDTOKeys)[number]> {}
+
+export const toNotificationChannelDTO = (notificationChannel: NotificationChannel): NotificationChannelDTO =>
+  pickDTOFields(notificationChannel, notificationChannelDTOKeys);
+
+
+const notificationAnalyticsDTOKeys = ["id", "campaignId", "segment", "channel", "createdAt"] as const;
+
+export interface NotificationAnalyticsDTO
+  extends Pick<NotificationAnalytics, (typeof notificationAnalyticsDTOKeys)[number]> {}
+
+export const toNotificationAnalyticsDTO = (notificationAnalytics: NotificationAnalytics): NotificationAnalyticsDTO =>
+  pickDTOFields(notificationAnalytics, notificationAnalyticsDTOKeys);
+

--- a/shared/offerEngineTables.ts
+++ b/shared/offerEngineTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // Offer Sources Configuration - Plugin-based integrations
 export const offerSources = pgTable("offer_sources", {
   id: serial("id").primaryKey(),
@@ -234,29 +236,111 @@ export const insertOfferAiOptimizationQueueSchema = createInsertSchema(offerAiOp
 });
 
 // Type exports
-export type OfferSource = typeof offerSources.$inferSelect;
-export type InsertOfferSource = z.infer<typeof insertOfferSourceSchema>;
+export type OfferSource = InferSelectModel<typeof offerSources>;
+export type InsertOfferSource = InferInsertModel<typeof offerSources>;
 
-export type OfferFeed = typeof offerFeed.$inferSelect;
-export type InsertOfferFeed = z.infer<typeof insertOfferFeedSchema>;
+export type OfferFeed = InferSelectModel<typeof offerFeed>;
+export type InsertOfferFeed = InferInsertModel<typeof offerFeed>;
 
-export type OfferAnalytics = typeof offerAnalytics.$inferSelect;
-export type InsertOfferAnalytics = z.infer<typeof insertOfferAnalyticsSchema>;
+export type OfferAnalytics = InferSelectModel<typeof offerAnalytics>;
+export type InsertOfferAnalytics = InferInsertModel<typeof offerAnalytics>;
 
-export type OfferPersonalizationRule = typeof offerPersonalizationRules.$inferSelect;
-export type InsertOfferPersonalizationRule = z.infer<typeof insertOfferPersonalizationRuleSchema>;
+export type OfferPersonalizationRule = InferSelectModel<typeof offerPersonalizationRules>;
+export type InsertOfferPersonalizationRule = InferInsertModel<typeof offerPersonalizationRules>;
 
-export type OfferExperiment = typeof offerExperiments.$inferSelect;
-export type InsertOfferExperiment = z.infer<typeof insertOfferExperimentSchema>;
+export type OfferExperiment = InferSelectModel<typeof offerExperiments>;
+export type InsertOfferExperiment = InferInsertModel<typeof offerExperiments>;
 
-export type OfferSyncHistory = typeof offerSyncHistory.$inferSelect;
-export type InsertOfferSyncHistory = z.infer<typeof insertOfferSyncHistorySchema>;
+export type OfferSyncHistory = InferSelectModel<typeof offerSyncHistory>;
+export type InsertOfferSyncHistory = InferInsertModel<typeof offerSyncHistory>;
 
-export type NeuronOfferAssignment = typeof neuronOfferAssignments.$inferSelect;
-export type InsertNeuronOfferAssignment = z.infer<typeof insertNeuronOfferAssignmentSchema>;
+export type NeuronOfferAssignment = InferSelectModel<typeof neuronOfferAssignments>;
+export type InsertNeuronOfferAssignment = InferInsertModel<typeof neuronOfferAssignments>;
 
-export type OfferComplianceRule = typeof offerComplianceRules.$inferSelect;
-export type InsertOfferComplianceRule = z.infer<typeof insertOfferComplianceRuleSchema>;
+export type OfferComplianceRule = InferSelectModel<typeof offerComplianceRules>;
+export type InsertOfferComplianceRule = InferInsertModel<typeof offerComplianceRules>;
 
-export type OfferAiOptimizationQueue = typeof offerAiOptimizationQueue.$inferSelect;
-export type InsertOfferAiOptimizationQueue = z.infer<typeof insertOfferAiOptimizationQueueSchema>;
+export type OfferAiOptimizationQueue = InferSelectModel<typeof offerAiOptimizationQueue>;
+export type InsertOfferAiOptimizationQueue = InferInsertModel<typeof offerAiOptimizationQueue>;
+
+// DTOs
+const offerSourceDTOKeys = ["id", "name", "slug", "type", "createdAt", "updatedAt", "description"] as const;
+
+export interface OfferSourceDTO
+  extends Pick<OfferSource, (typeof offerSourceDTOKeys)[number]> {}
+
+export const toOfferSourceDTO = (offerSource: OfferSource): OfferSourceDTO =>
+  pickDTOFields(offerSource, offerSourceDTOKeys);
+
+
+const offerFeedDTOKeys = ["id", "title", "slug", "category", "region", "priority", "createdAt", "updatedAt"] as const;
+
+export interface OfferFeedDTO
+  extends Pick<OfferFeed, (typeof offerFeedDTOKeys)[number]> {}
+
+export const toOfferFeedDTO = (offerFeed: OfferFeed): OfferFeedDTO =>
+  pickDTOFields(offerFeed, offerFeedDTOKeys);
+
+
+const offerAnalyticsDTOKeys = ["id", "sessionId", "neuronId", "userId", "offerId", "eventType"] as const;
+
+export interface OfferAnalyticsDTO
+  extends Pick<OfferAnalytics, (typeof offerAnalyticsDTOKeys)[number]> {}
+
+export const toOfferAnalyticsDTO = (offerAnalytics: OfferAnalytics): OfferAnalyticsDTO =>
+  pickDTOFields(offerAnalytics, offerAnalyticsDTOKeys);
+
+
+const offerPersonalizationRuleDTOKeys = ["id", "name", "priority", "createdAt", "updatedAt", "description"] as const;
+
+export interface OfferPersonalizationRuleDTO
+  extends Pick<OfferPersonalizationRule, (typeof offerPersonalizationRuleDTOKeys)[number]> {}
+
+export const toOfferPersonalizationRuleDTO = (offerPersonalizationRule: OfferPersonalizationRule): OfferPersonalizationRuleDTO =>
+  pickDTOFields(offerPersonalizationRule, offerPersonalizationRuleDTOKeys);
+
+
+const offerExperimentDTOKeys = ["id", "name", "status", "type", "createdAt", "updatedAt", "description"] as const;
+
+export interface OfferExperimentDTO
+  extends Pick<OfferExperiment, (typeof offerExperimentDTOKeys)[number]> {}
+
+export const toOfferExperimentDTO = (offerExperiment: OfferExperiment): OfferExperimentDTO =>
+  pickDTOFields(offerExperiment, offerExperimentDTOKeys);
+
+
+const offerSyncHistoryDTOKeys = ["id", "status", "sourceId"] as const;
+
+export interface OfferSyncHistoryDTO
+  extends Pick<OfferSyncHistory, (typeof offerSyncHistoryDTOKeys)[number]> {}
+
+export const toOfferSyncHistoryDTO = (offerSyncHistory: OfferSyncHistory): OfferSyncHistoryDTO =>
+  pickDTOFields(offerSyncHistory, offerSyncHistoryDTOKeys);
+
+
+const neuronOfferAssignmentDTOKeys = ["id", "neuronId", "offerId"] as const;
+
+export interface NeuronOfferAssignmentDTO
+  extends Pick<NeuronOfferAssignment, (typeof neuronOfferAssignmentDTOKeys)[number]> {}
+
+export const toNeuronOfferAssignmentDTO = (neuronOfferAssignment: NeuronOfferAssignment): NeuronOfferAssignmentDTO =>
+  pickDTOFields(neuronOfferAssignment, neuronOfferAssignmentDTOKeys);
+
+
+const offerComplianceRuleDTOKeys = ["id", "name", "severity", "createdAt", "description"] as const;
+
+export interface OfferComplianceRuleDTO
+  extends Pick<OfferComplianceRule, (typeof offerComplianceRuleDTOKeys)[number]> {}
+
+export const toOfferComplianceRuleDTO = (offerComplianceRule: OfferComplianceRule): OfferComplianceRuleDTO =>
+  pickDTOFields(offerComplianceRule, offerComplianceRuleDTOKeys);
+
+
+const offerAiOptimizationQueueDTOKeys = ["id", "status", "neuronId", "offerId", "priority", "createdAt"] as const;
+
+export interface OfferAiOptimizationQueueDTO
+  extends Pick<OfferAiOptimizationQueue, (typeof offerAiOptimizationQueueDTOKeys)[number]> {}
+
+export const toOfferAiOptimizationQueueDTO = (offerAiOptimizationQueue: OfferAiOptimizationQueue): OfferAiOptimizationQueueDTO =>
+  pickDTOFields(offerAiOptimizationQueue, offerAiOptimizationQueueDTOKeys);
+

--- a/shared/offlineAiTables.ts
+++ b/shared/offlineAiTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // ============================================================================
 // OFFLINE AI SYNC ENGINE + EDGE AI DEVICE RESILIENCE - BILLION-DOLLAR GRADE
 // ============================================================================
@@ -262,18 +264,18 @@ export const conflictResolutionLog = pgTable("conflict_resolution_log", {
 });
 
 // Type exports for TypeScript
-export type OfflineSyncQueue = typeof offlineSyncQueue.$inferSelect;
-export type InsertOfflineSyncQueue = typeof offlineSyncQueue.$inferInsert;
-export type EdgeAiModel = typeof edgeAiModels.$inferSelect;
-export type InsertEdgeAiModel = typeof edgeAiModels.$inferInsert;
-export type DeviceSyncState = typeof deviceSyncState.$inferSelect;
-export type InsertDeviceSyncState = typeof deviceSyncState.$inferInsert;
-export type OfflineAnalyticsBuffer = typeof offlineAnalyticsBuffer.$inferSelect;
-export type InsertOfflineAnalyticsBuffer = typeof offlineAnalyticsBuffer.$inferInsert;
-export type OfflineContentCache = typeof offlineContentCache.$inferSelect;
-export type InsertOfflineContentCache = typeof offlineContentCache.$inferInsert;
-export type ConflictResolutionLog = typeof conflictResolutionLog.$inferSelect;
-export type InsertConflictResolutionLog = typeof conflictResolutionLog.$inferInsert;
+export type OfflineSyncQueue = InferSelectModel<typeof offlineSyncQueue>;
+export type InsertOfflineSyncQueue = InferInsertModel<typeof offlineSyncQueue>;
+export type EdgeAiModel = InferSelectModel<typeof edgeAiModels>;
+export type InsertEdgeAiModel = InferInsertModel<typeof edgeAiModels>;
+export type DeviceSyncState = InferSelectModel<typeof deviceSyncState>;
+export type InsertDeviceSyncState = InferInsertModel<typeof deviceSyncState>;
+export type OfflineAnalyticsBuffer = InferSelectModel<typeof offlineAnalyticsBuffer>;
+export type InsertOfflineAnalyticsBuffer = InferInsertModel<typeof offlineAnalyticsBuffer>;
+export type OfflineContentCache = InferSelectModel<typeof offlineContentCache>;
+export type InsertOfflineContentCache = InferInsertModel<typeof offlineContentCache>;
+export type ConflictResolutionLog = InferSelectModel<typeof conflictResolutionLog>;
+export type InsertConflictResolutionLog = InferInsertModel<typeof conflictResolutionLog>;
 
 // Zod schemas for validation
 export const insertOfflineSyncQueueSchema = createInsertSchema(offlineSyncQueue);
@@ -282,3 +284,58 @@ export const insertDeviceSyncStateSchema = createInsertSchema(deviceSyncState);
 export const insertOfflineAnalyticsBufferSchema = createInsertSchema(offlineAnalyticsBuffer);
 export const insertOfflineContentCacheSchema = createInsertSchema(offlineContentCache);
 export const insertConflictResolutionLogSchema = createInsertSchema(conflictResolutionLog);
+
+// DTOs
+const offlineSyncQueueDTOKeys = ["id", "sessionId", "userId", "priority", "createdAt", "updatedAt", "eventType"] as const;
+
+export interface OfflineSyncQueueDTO
+  extends Pick<OfflineSyncQueue, (typeof offlineSyncQueueDTOKeys)[number]> {}
+
+export const toOfflineSyncQueueDTO = (offlineSyncQueue: OfflineSyncQueue): OfflineSyncQueueDTO =>
+  pickDTOFields(offlineSyncQueue, offlineSyncQueueDTOKeys);
+
+
+const edgeAiModelDTOKeys = ["id", "modelId", "createdAt", "updatedAt"] as const;
+
+export interface EdgeAiModelDTO
+  extends Pick<EdgeAiModel, (typeof edgeAiModelDTOKeys)[number]> {}
+
+export const toEdgeAiModelDTO = (edgeAiModel: EdgeAiModel): EdgeAiModelDTO =>
+  pickDTOFields(edgeAiModel, edgeAiModelDTOKeys);
+
+
+const deviceSyncStateDTOKeys = ["id", "userId", "createdAt", "updatedAt"] as const;
+
+export interface DeviceSyncStateDTO
+  extends Pick<DeviceSyncState, (typeof deviceSyncStateDTOKeys)[number]> {}
+
+export const toDeviceSyncStateDTO = (deviceSyncState: DeviceSyncState): DeviceSyncStateDTO =>
+  pickDTOFields(deviceSyncState, deviceSyncStateDTOKeys);
+
+
+const offlineAnalyticsBufferDTOKeys = ["id", "sessionId", "createdAt", "eventType"] as const;
+
+export interface OfflineAnalyticsBufferDTO
+  extends Pick<OfflineAnalyticsBuffer, (typeof offlineAnalyticsBufferDTOKeys)[number]> {}
+
+export const toOfflineAnalyticsBufferDTO = (offlineAnalyticsBuffer: OfflineAnalyticsBuffer): OfflineAnalyticsBufferDTO =>
+  pickDTOFields(offlineAnalyticsBuffer, offlineAnalyticsBufferDTOKeys);
+
+
+const offlineContentCacheDTOKeys = ["id", "priority", "createdAt", "updatedAt"] as const;
+
+export interface OfflineContentCacheDTO
+  extends Pick<OfflineContentCache, (typeof offlineContentCacheDTOKeys)[number]> {}
+
+export const toOfflineContentCacheDTO = (offlineContentCache: OfflineContentCache): OfflineContentCacheDTO =>
+  pickDTOFields(offlineContentCache, offlineContentCacheDTOKeys);
+
+
+const conflictResolutionLogDTOKeys = ["id", "sessionId", "userId", "createdAt"] as const;
+
+export interface ConflictResolutionLogDTO
+  extends Pick<ConflictResolutionLog, (typeof conflictResolutionLogDTOKeys)[number]> {}
+
+export const toConflictResolutionLogDTO = (conflictResolutionLog: ConflictResolutionLog): ConflictResolutionLogDTO =>
+  pickDTOFields(conflictResolutionLog, conflictResolutionLogDTOKeys);
+

--- a/shared/pluginTables.ts
+++ b/shared/pluginTables.ts
@@ -1,3 +1,5 @@
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 /**
  * AI Plugin Marketplace Database Tables
  * Enterprise-grade plugin management system with comprehensive tracking
@@ -297,23 +299,87 @@ export const insertPluginMarketplaceSchema = createInsertSchema(pluginMarketplac
 });
 
 // TypeScript types
-export type PluginManifest = typeof pluginManifests.$inferSelect;
-export type InsertPluginManifest = z.infer<typeof insertPluginManifestSchema>;
+export type PluginManifest = InferSelectModel<typeof pluginManifests>;
+export type InsertPluginManifest = InferInsertModel<typeof pluginManifests>;
 
-export type PluginInstance = typeof pluginInstances.$inferSelect;
-export type InsertPluginInstance = z.infer<typeof insertPluginInstanceSchema>;
+export type PluginInstance = InferSelectModel<typeof pluginInstances>;
+export type InsertPluginInstance = InferInsertModel<typeof pluginInstances>;
 
-export type PluginExecution = typeof pluginExecutions.$inferSelect;
-export type InsertPluginExecution = z.infer<typeof insertPluginExecutionSchema>;
+export type PluginExecution = InferSelectModel<typeof pluginExecutions>;
+export type InsertPluginExecution = InferInsertModel<typeof pluginExecutions>;
 
-export type PluginReview = typeof pluginReviews.$inferSelect;
-export type InsertPluginReview = z.infer<typeof insertPluginReviewSchema>;
+export type PluginReview = InferSelectModel<typeof pluginReviews>;
+export type InsertPluginReview = InferInsertModel<typeof pluginReviews>;
 
-export type PluginAnalytics = typeof pluginAnalytics.$inferSelect;
-export type InsertPluginAnalytics = z.infer<typeof insertPluginAnalyticsSchema>;
+export type PluginAnalytics = InferSelectModel<typeof pluginAnalytics>;
+export type InsertPluginAnalytics = InferInsertModel<typeof pluginAnalytics>;
 
-export type PluginDependency = typeof pluginDependencies.$inferSelect;
-export type InsertPluginDependency = z.infer<typeof insertPluginDependencySchema>;
+export type PluginDependency = InferSelectModel<typeof pluginDependencies>;
+export type InsertPluginDependency = InferInsertModel<typeof pluginDependencies>;
 
-export type PluginMarketplace = typeof pluginMarketplace.$inferSelect;
-export type InsertPluginMarketplace = z.infer<typeof insertPluginMarketplaceSchema>;
+export type PluginMarketplace = InferSelectModel<typeof pluginMarketplace>;
+export type InsertPluginMarketplace = InferInsertModel<typeof pluginMarketplace>;
+
+// DTOs
+const pluginManifestDTOKeys = ["id", "name", "type", "category", "createdAt", "updatedAt", "description", "version"] as const;
+
+export interface PluginManifestDTO
+  extends Pick<PluginManifest, (typeof pluginManifestDTOKeys)[number]> {}
+
+export const toPluginManifestDTO = (pluginManifest: PluginManifest): PluginManifestDTO =>
+  pickDTOFields(pluginManifest, pluginManifestDTOKeys);
+
+
+const pluginInstanceDTOKeys = ["id", "status", "neuronId", "createdAt", "updatedAt", "version"] as const;
+
+export interface PluginInstanceDTO
+  extends Pick<PluginInstance, (typeof pluginInstanceDTOKeys)[number]> {}
+
+export const toPluginInstanceDTO = (pluginInstance: PluginInstance): PluginInstanceDTO =>
+  pickDTOFields(pluginInstance, pluginInstanceDTOKeys);
+
+
+const pluginExecutionDTOKeys = ["id", "status", "sessionId", "neuronId", "userId", "priority", "createdAt"] as const;
+
+export interface PluginExecutionDTO
+  extends Pick<PluginExecution, (typeof pluginExecutionDTOKeys)[number]> {}
+
+export const toPluginExecutionDTO = (pluginExecution: PluginExecution): PluginExecutionDTO =>
+  pickDTOFields(pluginExecution, pluginExecutionDTOKeys);
+
+
+const pluginReviewDTOKeys = ["id", "title", "neuronId", "userId", "language", "createdAt", "updatedAt"] as const;
+
+export interface PluginReviewDTO
+  extends Pick<PluginReview, (typeof pluginReviewDTOKeys)[number]> {}
+
+export const toPluginReviewDTO = (pluginReview: PluginReview): PluginReviewDTO =>
+  pickDTOFields(pluginReview, pluginReviewDTOKeys);
+
+
+const pluginAnalyticsDTOKeys = ["id", "sessionId", "neuronId", "userId", "region", "country", "createdAt", "eventType"] as const;
+
+export interface PluginAnalyticsDTO
+  extends Pick<PluginAnalytics, (typeof pluginAnalyticsDTOKeys)[number]> {}
+
+export const toPluginAnalyticsDTO = (pluginAnalytics: PluginAnalytics): PluginAnalyticsDTO =>
+  pickDTOFields(pluginAnalytics, pluginAnalyticsDTOKeys);
+
+
+const pluginDependencyDTOKeys = ["id", "status", "createdAt", "updatedAt"] as const;
+
+export interface PluginDependencyDTO
+  extends Pick<PluginDependency, (typeof pluginDependencyDTOKeys)[number]> {}
+
+export const toPluginDependencyDTO = (pluginDependency: PluginDependency): PluginDependencyDTO =>
+  pickDTOFields(pluginDependency, pluginDependencyDTOKeys);
+
+
+const pluginMarketplaceDTOKeys = ["id", "name", "createdAt", "updatedAt", "description"] as const;
+
+export interface PluginMarketplaceDTO
+  extends Pick<PluginMarketplace, (typeof pluginMarketplaceDTOKeys)[number]> {}
+
+export const toPluginMarketplaceDTO = (pluginMarketplace: PluginMarketplace): PluginMarketplaceDTO =>
+  pickDTOFields(pluginMarketplace, pluginMarketplaceDTOKeys);
+

--- a/shared/promptEngineTables.ts
+++ b/shared/promptEngineTables.ts
@@ -1,6 +1,8 @@
 import { pgTable, serial, uuid, varchar, text, jsonb, integer, real, timestamp, boolean, index, foreignKey } from "drizzle-orm/pg-core";
 import { neurons } from "./schema";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // Core Prompt Templates - Foundation of the engine
 export const promptTemplates = pgTable("prompt_templates", {
   id: serial("id").primaryKey(),
@@ -377,17 +379,81 @@ export const promptQueue = pgTable("prompt_queue", {
 }));
 
 // Export all tables and types
-export type PromptTemplate = typeof promptTemplates.$inferSelect;
-export type NewPromptTemplate = typeof promptTemplates.$inferInsert;
-export type PromptExecution = typeof promptExecutions.$inferSelect;
-export type NewPromptExecution = typeof promptExecutions.$inferInsert;
-export type PromptGraph = typeof promptGraphs.$inferSelect;
-export type NewPromptGraph = typeof promptGraphs.$inferInsert;
-export type PromptGraphExecution = typeof promptGraphExecutions.$inferSelect;
-export type NewPromptGraphExecution = typeof promptGraphExecutions.$inferInsert;
-export type PromptOptimization = typeof promptOptimizations.$inferSelect;
-export type NewPromptOptimization = typeof promptOptimizations.$inferInsert;
-export type PromptAnalytics = typeof promptAnalytics.$inferSelect;
-export type NewPromptAnalytics = typeof promptAnalytics.$inferInsert;
-export type PromptQueueItem = typeof promptQueue.$inferSelect;
-export type NewPromptQueueItem = typeof promptQueue.$inferInsert;
+export type PromptTemplate = InferSelectModel<typeof promptTemplates>;
+export type NewPromptTemplate = InferInsertModel<typeof promptTemplates>;
+export type PromptExecution = InferSelectModel<typeof promptExecutions>;
+export type NewPromptExecution = InferInsertModel<typeof promptExecutions>;
+export type PromptGraph = InferSelectModel<typeof promptGraphs>;
+export type NewPromptGraph = InferInsertModel<typeof promptGraphs>;
+export type PromptGraphExecution = InferSelectModel<typeof promptGraphExecutions>;
+export type NewPromptGraphExecution = InferInsertModel<typeof promptGraphExecutions>;
+export type PromptOptimization = InferSelectModel<typeof promptOptimizations>;
+export type NewPromptOptimization = InferInsertModel<typeof promptOptimizations>;
+export type PromptAnalytics = InferSelectModel<typeof promptAnalytics>;
+export type NewPromptAnalytics = InferInsertModel<typeof promptAnalytics>;
+export type PromptQueueItem = InferSelectModel<typeof promptQueue>;
+export type NewPromptQueueItem = InferInsertModel<typeof promptQueue>;
+
+// DTOs
+const promptTemplateDTOKeys = ["id", "name", "status", "category", "neuronId", "createdAt", "updatedAt", "description"] as const;
+
+export interface PromptTemplateDTO
+  extends Pick<PromptTemplate, (typeof promptTemplateDTOKeys)[number]> {}
+
+export const toPromptTemplateDTO = (promptTemplate: PromptTemplate): PromptTemplateDTO =>
+  pickDTOFields(promptTemplate, promptTemplateDTOKeys);
+
+
+const promptExecutionDTOKeys = ["id", "status", "sessionId", "neuronId", "userId", "createdAt"] as const;
+
+export interface PromptExecutionDTO
+  extends Pick<PromptExecution, (typeof promptExecutionDTOKeys)[number]> {}
+
+export const toPromptExecutionDTO = (promptExecution: PromptExecution): PromptExecutionDTO =>
+  pickDTOFields(promptExecution, promptExecutionDTOKeys);
+
+
+const promptGraphDTOKeys = ["id", "name", "status", "category", "neuronId", "createdAt", "updatedAt", "description"] as const;
+
+export interface PromptGraphDTO
+  extends Pick<PromptGraph, (typeof promptGraphDTOKeys)[number]> {}
+
+export const toPromptGraphDTO = (promptGraph: PromptGraph): PromptGraphDTO =>
+  pickDTOFields(promptGraph, promptGraphDTOKeys);
+
+
+const promptGraphExecutionDTOKeys = ["id", "status", "sessionId", "neuronId", "userId", "createdAt"] as const;
+
+export interface PromptGraphExecutionDTO
+  extends Pick<PromptGraphExecution, (typeof promptGraphExecutionDTOKeys)[number]> {}
+
+export const toPromptGraphExecutionDTO = (promptGraphExecution: PromptGraphExecution): PromptGraphExecutionDTO =>
+  pickDTOFields(promptGraphExecution, promptGraphExecutionDTOKeys);
+
+
+const promptOptimizationDTOKeys = ["id", "status", "createdAt", "updatedAt"] as const;
+
+export interface PromptOptimizationDTO
+  extends Pick<PromptOptimization, (typeof promptOptimizationDTOKeys)[number]> {}
+
+export const toPromptOptimizationDTO = (promptOptimization: PromptOptimization): PromptOptimizationDTO =>
+  pickDTOFields(promptOptimization, promptOptimizationDTOKeys);
+
+
+const promptAnalyticsDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface PromptAnalyticsDTO
+  extends Pick<PromptAnalytics, (typeof promptAnalyticsDTOKeys)[number]> {}
+
+export const toPromptAnalyticsDTO = (promptAnalytics: PromptAnalytics): PromptAnalyticsDTO =>
+  pickDTOFields(promptAnalytics, promptAnalyticsDTOKeys);
+
+
+const promptQueueItemDTOKeys = ["id", "status", "neuronId", "userId", "priority", "createdAt", "updatedAt"] as const;
+
+export interface PromptQueueItemDTO
+  extends Pick<PromptQueueItem, (typeof promptQueueItemDTOKeys)[number]> {}
+
+export const toPromptQueueItemDTO = (promptQueueItem: PromptQueueItem): PromptQueueItemDTO =>
+  pickDTOFields(promptQueueItem, promptQueueItemDTOKeys);
+

--- a/shared/pwaTables.ts
+++ b/shared/pwaTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // PWA Installation tracking
 export const pwaInstalls = pgTable("pwa_installs", {
   id: serial("id").primaryKey(),
@@ -266,36 +268,148 @@ export const insertPWAPerformanceMetricsSchema = createInsertSchema(pwaPerforman
 });
 
 // Type exports
-export type PWAInstall = typeof pwaInstalls.$inferSelect;
-export type InsertPWAInstall = z.infer<typeof insertPWAInstallSchema>;
+export type PWAInstall = InferSelectModel<typeof pwaInstalls>;
+export type InsertPWAInstall = InferInsertModel<typeof pwaInstalls>;
 
-export type PushSubscription = typeof pushSubscriptions.$inferSelect;
-export type InsertPushSubscription = z.infer<typeof insertPushSubscriptionSchema>;
+export type PushSubscription = InferSelectModel<typeof pushSubscriptions>;
+export type InsertPushSubscription = InferInsertModel<typeof pushSubscriptions>;
 
-export type PWANotificationCampaign = typeof pwaNotificationCampaigns.$inferSelect;
-export type InsertPWANotificationCampaign = z.infer<typeof insertPWANotificationCampaignSchema>;
+export type PWANotificationCampaign = InferSelectModel<typeof pwaNotificationCampaigns>;
+export type InsertPWANotificationCampaign = InferInsertModel<typeof pwaNotificationCampaigns>;
 
-export type PWAUsageStats = typeof pwaUsageStats.$inferSelect;
-export type InsertPWAUsageStats = z.infer<typeof insertPWAUsageStatsSchema>;
+export type PWAUsageStats = InferSelectModel<typeof pwaUsageStats>;
+export type InsertPWAUsageStats = InferInsertModel<typeof pwaUsageStats>;
 
-export type OfflineQueueItem = typeof offlineQueue.$inferSelect;
-export type InsertOfflineQueueItem = z.infer<typeof insertOfflineQueueSchema>;
+export type OfflineQueueItem = InferSelectModel<typeof offlineQueue>;
+export type InsertOfflineQueueItem = InferInsertModel<typeof offlineQueue>;
 
 // New empire-grade types
-export type PWAAsoMetrics = typeof pwaAsoMetrics.$inferSelect;
-export type InsertPWAAsoMetrics = z.infer<typeof insertPWAAsoMetricsSchema>;
+export type PWAAsoMetrics = InferSelectModel<typeof pwaAsoMetrics>;
+export type InsertPWAAsoMetrics = InferInsertModel<typeof pwaAsoMetrics>;
 
-export type DeviceCapabilities = typeof deviceCapabilities.$inferSelect;
-export type InsertDeviceCapabilities = z.infer<typeof insertDeviceCapabilitiesSchema>;
+export type DeviceCapabilities = InferSelectModel<typeof deviceCapabilities>;
+export type InsertDeviceCapabilities = InferInsertModel<typeof deviceCapabilities>;
 
-export type DeepLinkAnalytics = typeof deepLinkAnalytics.$inferSelect;
-export type InsertDeepLinkAnalytics = z.infer<typeof insertDeepLinkAnalyticsSchema>;
+export type DeepLinkAnalytics = InferSelectModel<typeof deepLinkAnalytics>;
+export type InsertDeepLinkAnalytics = InferInsertModel<typeof deepLinkAnalytics>;
 
-export type MobileAppConfig = typeof mobileAppConfigs.$inferSelect;
-export type InsertMobileAppConfig = z.infer<typeof insertMobileAppConfigSchema>;
+export type MobileAppConfig = InferSelectModel<typeof mobileAppConfigs>;
+export type InsertMobileAppConfig = InferInsertModel<typeof mobileAppConfigs>;
 
-export type PushPersonalization = typeof pushPersonalization.$inferSelect;
-export type InsertPushPersonalization = z.infer<typeof insertPushPersonalizationSchema>;
+export type PushPersonalization = InferSelectModel<typeof pushPersonalization>;
+export type InsertPushPersonalization = InferInsertModel<typeof pushPersonalization>;
 
-export type PWAPerformanceMetrics = typeof pwaPerformanceMetrics.$inferSelect;
-export type InsertPWAPerformanceMetrics = z.infer<typeof insertPWAPerformanceMetricsSchema>;
+export type PWAPerformanceMetrics = InferSelectModel<typeof pwaPerformanceMetrics>;
+export type InsertPWAPerformanceMetrics = InferInsertModel<typeof pwaPerformanceMetrics>;
+
+export type PwaConfig = InferSelectModel<typeof pwaConfig>;
+export type InsertPwaConfig = InferInsertModel<typeof pwaConfig>;
+
+// DTOs
+const pWAInstallDTOKeys = ["id", "sessionId", "userAgent"] as const;
+
+export interface PWAInstallDTO
+  extends Pick<PWAInstall, (typeof pWAInstallDTOKeys)[number]> {}
+
+export const toPWAInstallDTO = (pWAInstall: PWAInstall): PWAInstallDTO =>
+  pickDTOFields(pWAInstall, pWAInstallDTOKeys);
+
+
+const pushSubscriptionDTOKeys = ["id", "sessionId", "createdAt", "updatedAt"] as const;
+
+export interface PushSubscriptionDTO
+  extends Pick<PushSubscription, (typeof pushSubscriptionDTOKeys)[number]> {}
+
+export const toPushSubscriptionDTO = (pushSubscription: PushSubscription): PushSubscriptionDTO =>
+  pickDTOFields(pushSubscription, pushSubscriptionDTOKeys);
+
+
+const pWANotificationCampaignDTOKeys = ["id", "title", "status", "createdAt"] as const;
+
+export interface PWANotificationCampaignDTO
+  extends Pick<PWANotificationCampaign, (typeof pWANotificationCampaignDTOKeys)[number]> {}
+
+export const toPWANotificationCampaignDTO = (pWANotificationCampaign: PWANotificationCampaign): PWANotificationCampaignDTO =>
+  pickDTOFields(pWANotificationCampaign, pWANotificationCampaignDTOKeys);
+
+
+const pWAUsageStatsDTOKeys = ["id", "sessionId", "date"] as const;
+
+export interface PWAUsageStatsDTO
+  extends Pick<PWAUsageStats, (typeof pWAUsageStatsDTOKeys)[number]> {}
+
+export const toPWAUsageStatsDTO = (pWAUsageStats: PWAUsageStats): PWAUsageStatsDTO =>
+  pickDTOFields(pWAUsageStats, pWAUsageStatsDTOKeys);
+
+
+const offlineQueueItemDTOKeys = ["id", "status", "sessionId", "createdAt"] as const;
+
+export interface OfflineQueueItemDTO
+  extends Pick<OfflineQueueItem, (typeof offlineQueueItemDTOKeys)[number]> {}
+
+export const toOfflineQueueItemDTO = (offlineQueueItem: OfflineQueueItem): OfflineQueueItemDTO =>
+  pickDTOFields(offlineQueueItem, offlineQueueItemDTOKeys);
+
+
+const pWAAsoMetricsDTOKeys = ["id", "appName", "platform"] as const;
+
+export interface PWAAsoMetricsDTO
+  extends Pick<PWAAsoMetrics, (typeof pWAAsoMetricsDTOKeys)[number]> {}
+
+export const toPWAAsoMetricsDTO = (pWAAsoMetrics: PWAAsoMetrics): PWAAsoMetricsDTO =>
+  pickDTOFields(pWAAsoMetrics, pWAAsoMetricsDTOKeys);
+
+
+const deviceCapabilitiesDTOKeys = ["id", "sessionId", "createdAt", "updatedAt"] as const;
+
+export interface DeviceCapabilitiesDTO
+  extends Pick<DeviceCapabilities, (typeof deviceCapabilitiesDTOKeys)[number]> {}
+
+export const toDeviceCapabilitiesDTO = (deviceCapabilities: DeviceCapabilities): DeviceCapabilitiesDTO =>
+  pickDTOFields(deviceCapabilities, deviceCapabilitiesDTOKeys);
+
+
+const deepLinkAnalyticsDTOKeys = ["id", "sessionId", "linkType"] as const;
+
+export interface DeepLinkAnalyticsDTO
+  extends Pick<DeepLinkAnalytics, (typeof deepLinkAnalyticsDTOKeys)[number]> {}
+
+export const toDeepLinkAnalyticsDTO = (deepLinkAnalytics: DeepLinkAnalytics): DeepLinkAnalyticsDTO =>
+  pickDTOFields(deepLinkAnalytics, deepLinkAnalyticsDTOKeys);
+
+
+const mobileAppConfigDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface MobileAppConfigDTO
+  extends Pick<MobileAppConfig, (typeof mobileAppConfigDTOKeys)[number]> {}
+
+export const toMobileAppConfigDTO = (mobileAppConfig: MobileAppConfig): MobileAppConfigDTO =>
+  pickDTOFields(mobileAppConfig, mobileAppConfigDTOKeys);
+
+
+const pushPersonalizationDTOKeys = ["id", "sessionId", "createdAt", "updatedAt"] as const;
+
+export interface PushPersonalizationDTO
+  extends Pick<PushPersonalization, (typeof pushPersonalizationDTOKeys)[number]> {}
+
+export const toPushPersonalizationDTO = (pushPersonalization: PushPersonalization): PushPersonalizationDTO =>
+  pickDTOFields(pushPersonalization, pushPersonalizationDTOKeys);
+
+
+const pWAPerformanceMetricsDTOKeys = ["id", "sessionId", "deviceId"] as const;
+
+export interface PWAPerformanceMetricsDTO
+  extends Pick<PWAPerformanceMetrics, (typeof pWAPerformanceMetricsDTOKeys)[number]> {}
+
+export const toPWAPerformanceMetricsDTO = (pWAPerformanceMetrics: PWAPerformanceMetrics): PWAPerformanceMetricsDTO =>
+  pickDTOFields(pWAPerformanceMetrics, pWAPerformanceMetricsDTOKeys);
+
+
+const pwaConfigDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface PwaConfigDTO
+  extends Pick<PwaConfig, (typeof pwaConfigDTOKeys)[number]> {}
+
+export const toPwaConfigDTO = (pwaConfig: PwaConfig): PwaConfigDTO =>
+  pickDTOFields(pwaConfig, pwaConfigDTOKeys);
+

--- a/shared/revenueSplitTables.ts
+++ b/shared/revenueSplitTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // Revenue Split Partners - Partner/Affiliate management with custom split configurations
 export const revenueSplitPartners = pgTable("revenue_split_partners", {
   id: serial("id").primaryKey(),
@@ -356,17 +358,81 @@ export const insertProfitForecastSchema = createInsertSchema(profitForecasts);
 export const insertRevenueSplitAnalyticsSchema = createInsertSchema(revenueSplitAnalytics);
 
 // TypeScript types
-export type RevenueSplitPartner = typeof revenueSplitPartners.$inferSelect;
-export type InsertRevenueSplitPartner = z.infer<typeof insertRevenueSplitPartnerSchema>;
-export type RevenueSplitRule = typeof revenueSplitRules.$inferSelect;
-export type InsertRevenueSplitRule = z.infer<typeof insertRevenueSplitRuleSchema>;
-export type RevenueSplitTransaction = typeof revenueSplitTransactions.$inferSelect;
-export type InsertRevenueSplitTransaction = z.infer<typeof insertRevenueSplitTransactionSchema>;
-export type RevenueSplitPayout = typeof revenueSplitPayouts.$inferSelect;
-export type InsertRevenueSplitPayout = z.infer<typeof insertRevenueSplitPayoutSchema>;
-export type ProfitForecastModel = typeof profitForecastModels.$inferSelect;
-export type InsertProfitForecastModel = z.infer<typeof insertProfitForecastModelSchema>;
-export type ProfitForecast = typeof profitForecasts.$inferSelect;
-export type InsertProfitForecast = z.infer<typeof insertProfitForecastSchema>;
-export type RevenueSplitAnalytics = typeof revenueSplitAnalytics.$inferSelect;
-export type InsertRevenueSplitAnalytics = z.infer<typeof insertRevenueSplitAnalyticsSchema>;
+export type RevenueSplitPartner = InferSelectModel<typeof revenueSplitPartners>;
+export type InsertRevenueSplitPartner = InferInsertModel<typeof revenueSplitPartners>;
+export type RevenueSplitRule = InferSelectModel<typeof revenueSplitRules>;
+export type InsertRevenueSplitRule = InferInsertModel<typeof revenueSplitRules>;
+export type RevenueSplitTransaction = InferSelectModel<typeof revenueSplitTransactions>;
+export type InsertRevenueSplitTransaction = InferInsertModel<typeof revenueSplitTransactions>;
+export type RevenueSplitPayout = InferSelectModel<typeof revenueSplitPayouts>;
+export type InsertRevenueSplitPayout = InferInsertModel<typeof revenueSplitPayouts>;
+export type ProfitForecastModel = InferSelectModel<typeof profitForecastModels>;
+export type InsertProfitForecastModel = InferInsertModel<typeof profitForecastModels>;
+export type ProfitForecast = InferSelectModel<typeof profitForecasts>;
+export type InsertProfitForecast = InferInsertModel<typeof profitForecasts>;
+export type RevenueSplitAnalytics = InferSelectModel<typeof revenueSplitAnalytics>;
+export type InsertRevenueSplitAnalytics = InferInsertModel<typeof revenueSplitAnalytics>;
+
+// DTOs
+const revenueSplitPartnerDTOKeys = ["id", "status", "createdAt", "updatedAt"] as const;
+
+export interface RevenueSplitPartnerDTO
+  extends Pick<RevenueSplitPartner, (typeof revenueSplitPartnerDTOKeys)[number]> {}
+
+export const toRevenueSplitPartnerDTO = (revenueSplitPartner: RevenueSplitPartner): RevenueSplitPartnerDTO =>
+  pickDTOFields(revenueSplitPartner, revenueSplitPartnerDTOKeys);
+
+
+const revenueSplitRuleDTOKeys = ["id", "ruleId", "vertical", "priority", "createdAt", "updatedAt"] as const;
+
+export interface RevenueSplitRuleDTO
+  extends Pick<RevenueSplitRule, (typeof revenueSplitRuleDTOKeys)[number]> {}
+
+export const toRevenueSplitRuleDTO = (revenueSplitRule: RevenueSplitRule): RevenueSplitRuleDTO =>
+  pickDTOFields(revenueSplitRule, revenueSplitRuleDTOKeys);
+
+
+const revenueSplitTransactionDTOKeys = ["id", "status", "ruleId", "vertical", "createdAt", "productId"] as const;
+
+export interface RevenueSplitTransactionDTO
+  extends Pick<RevenueSplitTransaction, (typeof revenueSplitTransactionDTOKeys)[number]> {}
+
+export const toRevenueSplitTransactionDTO = (revenueSplitTransaction: RevenueSplitTransaction): RevenueSplitTransactionDTO =>
+  pickDTOFields(revenueSplitTransaction, revenueSplitTransactionDTOKeys);
+
+
+const revenueSplitPayoutDTOKeys = ["id", "status", "createdAt"] as const;
+
+export interface RevenueSplitPayoutDTO
+  extends Pick<RevenueSplitPayout, (typeof revenueSplitPayoutDTOKeys)[number]> {}
+
+export const toRevenueSplitPayoutDTO = (revenueSplitPayout: RevenueSplitPayout): RevenueSplitPayoutDTO =>
+  pickDTOFields(revenueSplitPayout, revenueSplitPayoutDTOKeys);
+
+
+const profitForecastModelDTOKeys = ["id", "status", "modelId", "createdAt", "updatedAt", "version"] as const;
+
+export interface ProfitForecastModelDTO
+  extends Pick<ProfitForecastModel, (typeof profitForecastModelDTOKeys)[number]> {}
+
+export const toProfitForecastModelDTO = (profitForecastModel: ProfitForecastModel): ProfitForecastModelDTO =>
+  pickDTOFields(profitForecastModel, profitForecastModelDTOKeys);
+
+
+const profitForecastDTOKeys = ["id", "status", "modelId", "createdAt"] as const;
+
+export interface ProfitForecastDTO
+  extends Pick<ProfitForecast, (typeof profitForecastDTOKeys)[number]> {}
+
+export const toProfitForecastDTO = (profitForecast: ProfitForecast): ProfitForecastDTO =>
+  pickDTOFields(profitForecast, profitForecastDTOKeys);
+
+
+const revenueSplitAnalyticsDTOKeys = ["id", "vertical", "createdAt"] as const;
+
+export interface RevenueSplitAnalyticsDTO
+  extends Pick<RevenueSplitAnalytics, (typeof revenueSplitAnalyticsDTOKeys)[number]> {}
+
+export const toRevenueSplitAnalyticsDTO = (revenueSplitAnalytics: RevenueSplitAnalytics): RevenueSplitAnalyticsDTO =>
+  pickDTOFields(revenueSplitAnalytics, revenueSplitAnalyticsDTOKeys);
+

--- a/shared/rlhfTables.ts
+++ b/shared/rlhfTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // ==========================================
 // RLHF + PERSONA FUSION ENGINE TABLES
 // ==========================================
@@ -350,17 +352,81 @@ export const insertPersonaSimulationSchema = createInsertSchema(personaSimulatio
 export const insertFederationRlhfSyncSchema = createInsertSchema(federationRlhfSync);
 
 // TypeScript types
-export type RlhfFeedback = typeof rlhfFeedback.$inferSelect;
-export type NewRlhfFeedback = typeof rlhfFeedback.$inferInsert;
-export type AgentReward = typeof agentRewards.$inferSelect;
-export type NewAgentReward = typeof agentRewards.$inferInsert;
-export type PersonaProfile = typeof personaProfiles.$inferSelect;
-export type NewPersonaProfile = typeof personaProfiles.$inferInsert;
-export type PersonaEvolution = typeof personaEvolution.$inferSelect;
-export type NewPersonaEvolution = typeof personaEvolution.$inferInsert;
-export type RlhfTrainingSession = typeof rlhfTrainingSessions.$inferSelect;
-export type NewRlhfTrainingSession = typeof rlhfTrainingSessions.$inferInsert;
-export type PersonaSimulation = typeof personaSimulations.$inferSelect;
-export type NewPersonaSimulation = typeof personaSimulations.$inferInsert;
-export type FederationRlhfSync = typeof federationRlhfSync.$inferSelect;
-export type NewFederationRlhfSync = typeof federationRlhfSync.$inferInsert;
+export type RlhfFeedback = InferSelectModel<typeof rlhfFeedback>;
+export type NewRlhfFeedback = InferInsertModel<typeof rlhfFeedback>;
+export type AgentReward = InferSelectModel<typeof agentRewards>;
+export type NewAgentReward = InferInsertModel<typeof agentRewards>;
+export type PersonaProfile = InferSelectModel<typeof personaProfiles>;
+export type NewPersonaProfile = InferInsertModel<typeof personaProfiles>;
+export type PersonaEvolution = InferSelectModel<typeof personaEvolution>;
+export type NewPersonaEvolution = InferInsertModel<typeof personaEvolution>;
+export type RlhfTrainingSession = InferSelectModel<typeof rlhfTrainingSessions>;
+export type NewRlhfTrainingSession = InferInsertModel<typeof rlhfTrainingSessions>;
+export type PersonaSimulation = InferSelectModel<typeof personaSimulations>;
+export type NewPersonaSimulation = InferInsertModel<typeof personaSimulations>;
+export type FederationRlhfSync = InferSelectModel<typeof federationRlhfSync>;
+export type NewFederationRlhfSync = InferInsertModel<typeof federationRlhfSync>;
+
+// DTOs
+const rlhfFeedbackDTOKeys = ["id", "sessionId", "userId", "createdAt"] as const;
+
+export interface RlhfFeedbackDTO
+  extends Pick<RlhfFeedback, (typeof rlhfFeedbackDTOKeys)[number]> {}
+
+export const toRlhfFeedbackDTO = (rlhfFeedback: RlhfFeedback): RlhfFeedbackDTO =>
+  pickDTOFields(rlhfFeedback, rlhfFeedbackDTOKeys);
+
+
+const agentRewardDTOKeys = ["id", "createdAt", "rewardId"] as const;
+
+export interface AgentRewardDTO
+  extends Pick<AgentReward, (typeof agentRewardDTOKeys)[number]> {}
+
+export const toAgentRewardDTO = (agentReward: AgentReward): AgentRewardDTO =>
+  pickDTOFields(agentReward, agentRewardDTOKeys);
+
+
+const personaProfileDTOKeys = ["id", "sessionId", "userId", "version"] as const;
+
+export interface PersonaProfileDTO
+  extends Pick<PersonaProfile, (typeof personaProfileDTOKeys)[number]> {}
+
+export const toPersonaProfileDTO = (personaProfile: PersonaProfile): PersonaProfileDTO =>
+  pickDTOFields(personaProfile, personaProfileDTOKeys);
+
+
+const personaEvolutionDTOKeys = ["id", "evolutionId", "evolutionType"] as const;
+
+export interface PersonaEvolutionDTO
+  extends Pick<PersonaEvolution, (typeof personaEvolutionDTOKeys)[number]> {}
+
+export const toPersonaEvolutionDTO = (personaEvolution: PersonaEvolution): PersonaEvolutionDTO =>
+  pickDTOFields(personaEvolution, personaEvolutionDTOKeys);
+
+
+const rlhfTrainingSessionDTOKeys = ["id", "status", "sessionId"] as const;
+
+export interface RlhfTrainingSessionDTO
+  extends Pick<RlhfTrainingSession, (typeof rlhfTrainingSessionDTOKeys)[number]> {}
+
+export const toRlhfTrainingSessionDTO = (rlhfTrainingSession: RlhfTrainingSession): RlhfTrainingSessionDTO =>
+  pickDTOFields(rlhfTrainingSession, rlhfTrainingSessionDTOKeys);
+
+
+const personaSimulationDTOKeys = ["id", "status", "createdAt"] as const;
+
+export interface PersonaSimulationDTO
+  extends Pick<PersonaSimulation, (typeof personaSimulationDTOKeys)[number]> {}
+
+export const toPersonaSimulationDTO = (personaSimulation: PersonaSimulation): PersonaSimulationDTO =>
+  pickDTOFields(personaSimulation, personaSimulationDTOKeys);
+
+
+const federationRlhfSyncDTOKeys = ["id", "status", "syncId"] as const;
+
+export interface FederationRlhfSyncDTO
+  extends Pick<FederationRlhfSync, (typeof federationRlhfSyncDTOKeys)[number]> {}
+
+export const toFederationRlhfSyncDTO = (federationRlhfSync: FederationRlhfSync): FederationRlhfSyncDTO =>
+  pickDTOFields(federationRlhfSync, federationRlhfSyncDTOKeys);
+

--- a/shared/saasTables.ts
+++ b/shared/saasTables.ts
@@ -1,3 +1,5 @@
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // SaaS-specific database tables for neuron-software-saas
 import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, decimal } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
@@ -229,29 +231,111 @@ export const insertSaasContentSchema = createInsertSchema(saasContent).omit({
 });
 
 // Types
-export type SaasTool = typeof saasTools.$inferSelect;
-export type InsertSaasTool = z.infer<typeof insertSaasToolSchema>;
+export type SaasTool = InferSelectModel<typeof saasTools>;
+export type InsertSaasTool = InferInsertModel<typeof saasTools>;
 
-export type SaaSCategory = typeof saasCategories.$inferSelect;
-export type InsertSaaSCategory = z.infer<typeof insertSaasCategorySchema>;
+export type SaaSCategory = InferSelectModel<typeof saasCategories>;
+export type InsertSaaSCategory = InferInsertModel<typeof saasCategories>;
 
-export type SaaSStack = typeof saasStacks.$inferSelect;
-export type InsertSaaSStack = z.infer<typeof insertSaasStackSchema>;
+export type SaaSStack = InferSelectModel<typeof saasStacks>;
+export type InsertSaaSStack = InferInsertModel<typeof saasStacks>;
 
-export type SaaSReview = typeof saasReviews.$inferSelect;
-export type InsertSaaSReview = z.infer<typeof insertSaasReviewSchema>;
+export type SaaSReview = InferSelectModel<typeof saasReviews>;
+export type InsertSaaSReview = InferInsertModel<typeof saasReviews>;
 
-export type SaaSComparison = typeof saasComparisons.$inferSelect;
-export type InsertSaaSComparison = z.infer<typeof insertSaasComparisonSchema>;
+export type SaaSComparison = InferSelectModel<typeof saasComparisons>;
+export type InsertSaaSComparison = InferInsertModel<typeof saasComparisons>;
 
-export type SaaSDeal = typeof saasDeals.$inferSelect;
-export type InsertSaaSDeal = z.infer<typeof insertSaasDealSchema>;
+export type SaaSDeal = InferSelectModel<typeof saasDeals>;
+export type InsertSaaSDeal = InferInsertModel<typeof saasDeals>;
 
-export type SaaSQuizResult = typeof saasQuizResults.$inferSelect;
-export type InsertSaaSQuizResult = z.infer<typeof insertSaasQuizResultSchema>;
+export type SaaSQuizResult = InferSelectModel<typeof saasQuizResults>;
+export type InsertSaaSQuizResult = InferInsertModel<typeof saasQuizResults>;
 
-export type SaaSCalculatorResult = typeof saasCalculatorResults.$inferSelect;
-export type InsertSaaSCalculatorResult = z.infer<typeof insertSaasCalculatorResultSchema>;
+export type SaaSCalculatorResult = InferSelectModel<typeof saasCalculatorResults>;
+export type InsertSaaSCalculatorResult = InferInsertModel<typeof saasCalculatorResults>;
 
-export type SaaSContent = typeof saasContent.$inferSelect;
-export type InsertSaaSContent = z.infer<typeof insertSaasContentSchema>;
+export type SaaSContent = InferSelectModel<typeof saasContent>;
+export type InsertSaaSContent = InferInsertModel<typeof saasContent>;
+
+// DTOs
+const saasToolDTOKeys = ["id", "name", "slug", "category", "createdAt", "updatedAt", "description"] as const;
+
+export interface SaasToolDTO
+  extends Pick<SaasTool, (typeof saasToolDTOKeys)[number]> {}
+
+export const toSaasToolDTO = (saasTool: SaasTool): SaasToolDTO =>
+  pickDTOFields(saasTool, saasToolDTOKeys);
+
+
+const saaSCategoryDTOKeys = ["id", "name", "slug", "createdAt", "description"] as const;
+
+export interface SaaSCategoryDTO
+  extends Pick<SaaSCategory, (typeof saaSCategoryDTOKeys)[number]> {}
+
+export const toSaaSCategoryDTO = (saaSCategory: SaaSCategory): SaaSCategoryDTO =>
+  pickDTOFields(saaSCategory, saaSCategoryDTOKeys);
+
+
+const saaSStackDTOKeys = ["id", "name", "sessionId", "userId", "createdAt", "updatedAt", "description"] as const;
+
+export interface SaaSStackDTO
+  extends Pick<SaaSStack, (typeof saaSStackDTOKeys)[number]> {}
+
+export const toSaaSStackDTO = (saaSStack: SaaSStack): SaaSStackDTO =>
+  pickDTOFields(saaSStack, saaSStackDTOKeys);
+
+
+const saaSReviewDTOKeys = ["id", "title", "sessionId", "userId", "createdAt", "toolId"] as const;
+
+export interface SaaSReviewDTO
+  extends Pick<SaaSReview, (typeof saaSReviewDTOKeys)[number]> {}
+
+export const toSaaSReviewDTO = (saaSReview: SaaSReview): SaaSReviewDTO =>
+  pickDTOFields(saaSReview, saaSReviewDTOKeys);
+
+
+const saaSComparisonDTOKeys = ["id", "title", "slug", "category", "createdAt", "updatedAt"] as const;
+
+export interface SaaSComparisonDTO
+  extends Pick<SaaSComparison, (typeof saaSComparisonDTOKeys)[number]> {}
+
+export const toSaaSComparisonDTO = (saaSComparison: SaaSComparison): SaaSComparisonDTO =>
+  pickDTOFields(saaSComparison, saaSComparisonDTOKeys);
+
+
+const saaSDealDTOKeys = ["id", "title", "createdAt", "updatedAt", "description", "toolId"] as const;
+
+export interface SaaSDealDTO
+  extends Pick<SaaSDeal, (typeof saaSDealDTOKeys)[number]> {}
+
+export const toSaaSDealDTO = (saaSDeal: SaaSDeal): SaaSDealDTO =>
+  pickDTOFields(saaSDeal, saaSDealDTOKeys);
+
+
+const saaSQuizResultDTOKeys = ["id", "sessionId", "userId", "createdAt", "budget", "quizType"] as const;
+
+export interface SaaSQuizResultDTO
+  extends Pick<SaaSQuizResult, (typeof saaSQuizResultDTOKeys)[number]> {}
+
+export const toSaaSQuizResultDTO = (saaSQuizResult: SaaSQuizResult): SaaSQuizResultDTO =>
+  pickDTOFields(saaSQuizResult, saaSQuizResultDTOKeys);
+
+
+const saaSCalculatorResultDTOKeys = ["id", "sessionId", "createdAt"] as const;
+
+export interface SaaSCalculatorResultDTO
+  extends Pick<SaaSCalculatorResult, (typeof saaSCalculatorResultDTOKeys)[number]> {}
+
+export const toSaaSCalculatorResultDTO = (saaSCalculatorResult: SaaSCalculatorResult): SaaSCalculatorResultDTO =>
+  pickDTOFields(saaSCalculatorResult, saaSCalculatorResultDTOKeys);
+
+
+const saaSContentDTOKeys = ["id", "title", "slug", "category", "createdAt", "updatedAt", "description"] as const;
+
+export interface SaaSContentDTO
+  extends Pick<SaaSContent, (typeof saaSContentDTOKeys)[number]> {}
+
+export const toSaaSContentDTO = (saaSContent: SaaSContent): SaaSContentDTO =>
+  pickDTOFields(saaSContent, saaSContentDTOKeys);
+

--- a/shared/semanticTables.ts
+++ b/shared/semanticTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // Semantic Graph Nodes - Core entities in the knowledge graph
 export const semanticNodes = pgTable("semantic_nodes", {
   id: serial("id").primaryKey(),
@@ -195,26 +197,99 @@ export const insertGraphAuditResultSchema = createInsertSchema(graphAuditResults
 });
 
 // Types
-export type SemanticNode = typeof semanticNodes.$inferSelect;
-export type InsertSemanticNode = z.infer<typeof insertSemanticNodeSchema>;
+export type SemanticNode = InferSelectModel<typeof semanticNodes>;
+export type InsertSemanticNode = InferInsertModel<typeof semanticNodes>;
 
-export type SemanticEdge = typeof semanticEdges.$inferSelect;
-export type InsertSemanticEdge = z.infer<typeof insertSemanticEdgeSchema>;
+export type SemanticEdge = InferSelectModel<typeof semanticEdges>;
+export type InsertSemanticEdge = InferInsertModel<typeof semanticEdges>;
 
-export type UserIntentVector = typeof userIntentVectors.$inferSelect;
-export type InsertUserIntentVector = z.infer<typeof insertUserIntentVectorSchema>;
+export type UserIntentVector = InferSelectModel<typeof userIntentVectors>;
+export type InsertUserIntentVector = InferInsertModel<typeof userIntentVectors>;
 
-export type VectorSimilarityIndex = typeof vectorSimilarityIndex.$inferSelect;
-export type InsertVectorSimilarityIndex = z.infer<typeof insertVectorSimilarityIndexSchema>;
+export type VectorSimilarityIndex = InferSelectModel<typeof vectorSimilarityIndex>;
+export type InsertVectorSimilarityIndex = InferInsertModel<typeof vectorSimilarityIndex>;
 
-export type SemanticSearchQuery = typeof semanticSearchQueries.$inferSelect;
-export type InsertSemanticSearchQuery = z.infer<typeof insertSemanticSearchQuerySchema>;
+export type SemanticSearchQuery = InferSelectModel<typeof semanticSearchQueries>;
+export type InsertSemanticSearchQuery = InferInsertModel<typeof semanticSearchQueries>;
 
-export type RealtimeRecommendation = typeof realtimeRecommendations.$inferSelect;
-export type InsertRealtimeRecommendation = z.infer<typeof insertRealtimeRecommendationSchema>;
+export type RealtimeRecommendation = InferSelectModel<typeof realtimeRecommendations>;
+export type InsertRealtimeRecommendation = InferInsertModel<typeof realtimeRecommendations>;
 
-export type GraphAnalytics = typeof graphAnalytics.$inferSelect;
-export type InsertGraphAnalytics = z.infer<typeof insertGraphAnalyticsSchema>;
+export type GraphAnalytics = InferSelectModel<typeof graphAnalytics>;
+export type InsertGraphAnalytics = InferInsertModel<typeof graphAnalytics>;
 
-export type GraphAuditResult = typeof graphAuditResults.$inferSelect;
-export type InsertGraphAuditResult = z.infer<typeof insertGraphAuditResultSchema>;
+export type GraphAuditResult = InferSelectModel<typeof graphAuditResults>;
+export type InsertGraphAuditResult = InferInsertModel<typeof graphAuditResults>;
+
+// DTOs
+const semanticNodeDTOKeys = ["id", "title", "slug", "status", "neuronId", "createdAt", "updatedAt", "description"] as const;
+
+export interface SemanticNodeDTO
+  extends Pick<SemanticNode, (typeof semanticNodeDTOKeys)[number]> {}
+
+export const toSemanticNodeDTO = (semanticNode: SemanticNode): SemanticNodeDTO =>
+  pickDTOFields(semanticNode, semanticNodeDTOKeys);
+
+
+const semanticEdgeDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface SemanticEdgeDTO
+  extends Pick<SemanticEdge, (typeof semanticEdgeDTOKeys)[number]> {}
+
+export const toSemanticEdgeDTO = (semanticEdge: SemanticEdge): SemanticEdgeDTO =>
+  pickDTOFields(semanticEdge, semanticEdgeDTOKeys);
+
+
+const userIntentVectorDTOKeys = ["id", "sessionId", "userId", "createdAt", "updatedAt"] as const;
+
+export interface UserIntentVectorDTO
+  extends Pick<UserIntentVector, (typeof userIntentVectorDTOKeys)[number]> {}
+
+export const toUserIntentVectorDTO = (userIntentVector: UserIntentVector): UserIntentVectorDTO =>
+  pickDTOFields(userIntentVector, userIntentVectorDTOKeys);
+
+
+const vectorSimilarityIndexDTOKeys = ["id", "nodeId", "similarNodeId"] as const;
+
+export interface VectorSimilarityIndexDTO
+  extends Pick<VectorSimilarityIndex, (typeof vectorSimilarityIndexDTOKeys)[number]> {}
+
+export const toVectorSimilarityIndexDTO = (vectorSimilarityIndex: VectorSimilarityIndex): VectorSimilarityIndexDTO =>
+  pickDTOFields(vectorSimilarityIndex, vectorSimilarityIndexDTOKeys);
+
+
+const semanticSearchQueryDTOKeys = ["id", "sessionId", "neuronId", "userId", "vertical", "createdAt"] as const;
+
+export interface SemanticSearchQueryDTO
+  extends Pick<SemanticSearchQuery, (typeof semanticSearchQueryDTOKeys)[number]> {}
+
+export const toSemanticSearchQueryDTO = (semanticSearchQuery: SemanticSearchQuery): SemanticSearchQueryDTO =>
+  pickDTOFields(semanticSearchQuery, semanticSearchQueryDTOKeys);
+
+
+const realtimeRecommendationDTOKeys = ["id", "sessionId", "userId", "createdAt"] as const;
+
+export interface RealtimeRecommendationDTO
+  extends Pick<RealtimeRecommendation, (typeof realtimeRecommendationDTOKeys)[number]> {}
+
+export const toRealtimeRecommendationDTO = (realtimeRecommendation: RealtimeRecommendation): RealtimeRecommendationDTO =>
+  pickDTOFields(realtimeRecommendation, realtimeRecommendationDTOKeys);
+
+
+const graphAnalyticsDTOKeys = ["id", "neuronId", "vertical", "createdAt"] as const;
+
+export interface GraphAnalyticsDTO
+  extends Pick<GraphAnalytics, (typeof graphAnalyticsDTOKeys)[number]> {}
+
+export const toGraphAnalyticsDTO = (graphAnalytics: GraphAnalytics): GraphAnalyticsDTO =>
+  pickDTOFields(graphAnalytics, graphAnalyticsDTOKeys);
+
+
+const graphAuditResultDTOKeys = ["id", "severity", "createdAt"] as const;
+
+export interface GraphAuditResultDTO
+  extends Pick<GraphAuditResult, (typeof graphAuditResultDTOKeys)[number]> {}
+
+export const toGraphAuditResultDTO = (graphAuditResult: GraphAuditResult): GraphAuditResultDTO =>
+  pickDTOFields(graphAuditResult, graphAuditResultDTOKeys);
+

--- a/shared/smartFunnelTables.ts
+++ b/shared/smartFunnelTables.ts
@@ -1,3 +1,5 @@
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 /**
  * Smart Funnel Generator Database Schema
  * Billion-Dollar Empire Grade Universal Funnel Engine
@@ -348,23 +350,87 @@ export const selectFunnelOptimizationSchema = createSelectSchema(funnelOptimizat
 // TYPE EXPORTS
 // =====================================================
 
-export type FunnelBlueprint = typeof funnelBlueprints.$inferSelect;
-export type InsertFunnelBlueprint = typeof funnelBlueprints.$inferInsert;
+export type FunnelBlueprint = InferSelectModel<typeof funnelBlueprints>;
+export type InsertFunnelBlueprint = InferInsertModel<typeof funnelBlueprints>;
 
-export type FunnelInstance = typeof funnelInstances.$inferSelect;
-export type InsertFunnelInstance = typeof funnelInstances.$inferInsert;
+export type FunnelInstance = InferSelectModel<typeof funnelInstances>;
+export type InsertFunnelInstance = InferInsertModel<typeof funnelInstances>;
 
-export type FunnelEvent = typeof funnelEvents.$inferSelect;
-export type InsertFunnelEvent = typeof funnelEvents.$inferInsert;
+export type FunnelEvent = InferSelectModel<typeof funnelEvents>;
+export type InsertFunnelEvent = InferInsertModel<typeof funnelEvents>;
 
-export type FunnelExperiment = typeof funnelExperiments.$inferSelect;
-export type InsertFunnelExperiment = typeof funnelExperiments.$inferInsert;
+export type FunnelExperiment = InferSelectModel<typeof funnelExperiments>;
+export type InsertFunnelExperiment = InferInsertModel<typeof funnelExperiments>;
 
-export type FunnelAnalytics = typeof funnelAnalytics.$inferSelect;
-export type InsertFunnelAnalytics = typeof funnelAnalytics.$inferInsert;
+export type FunnelAnalytics = InferSelectModel<typeof funnelAnalytics>;
+export type InsertFunnelAnalytics = InferInsertModel<typeof funnelAnalytics>;
 
-export type FunnelLifecycleIntegration = typeof funnelLifecycleIntegrations.$inferSelect;
-export type InsertFunnelLifecycleIntegration = typeof funnelLifecycleIntegrations.$inferInsert;
+export type FunnelLifecycleIntegration = InferSelectModel<typeof funnelLifecycleIntegrations>;
+export type InsertFunnelLifecycleIntegration = InferInsertModel<typeof funnelLifecycleIntegrations>;
 
-export type FunnelOptimization = typeof funnelOptimizations.$inferSelect;
-export type InsertFunnelOptimization = typeof funnelOptimizations.$inferInsert;
+export type FunnelOptimization = InferSelectModel<typeof funnelOptimizations>;
+export type InsertFunnelOptimization = InferInsertModel<typeof funnelOptimizations>;
+
+// DTOs
+const funnelBlueprintDTOKeys = ["id", "name", "status", "type", "vertical", "priority", "description"] as const;
+
+export interface FunnelBlueprintDTO
+  extends Pick<FunnelBlueprint, (typeof funnelBlueprintDTOKeys)[number]> {}
+
+export const toFunnelBlueprintDTO = (funnelBlueprint: FunnelBlueprint): FunnelBlueprintDTO =>
+  pickDTOFields(funnelBlueprint, funnelBlueprintDTOKeys);
+
+
+const funnelInstanceDTOKeys = ["id", "status", "blueprint_id"] as const;
+
+export interface FunnelInstanceDTO
+  extends Pick<FunnelInstance, (typeof funnelInstanceDTOKeys)[number]> {}
+
+export const toFunnelInstanceDTO = (funnelInstance: FunnelInstance): FunnelInstanceDTO =>
+  pickDTOFields(funnelInstance, funnelInstanceDTOKeys);
+
+
+const funnelEventDTOKeys = ["id", "instance_id", "block_id"] as const;
+
+export interface FunnelEventDTO
+  extends Pick<FunnelEvent, (typeof funnelEventDTOKeys)[number]> {}
+
+export const toFunnelEventDTO = (funnelEvent: FunnelEvent): FunnelEventDTO =>
+  pickDTOFields(funnelEvent, funnelEventDTOKeys);
+
+
+const funnelExperimentDTOKeys = ["id", "name", "status", "description"] as const;
+
+export interface FunnelExperimentDTO
+  extends Pick<FunnelExperiment, (typeof funnelExperimentDTOKeys)[number]> {}
+
+export const toFunnelExperimentDTO = (funnelExperiment: FunnelExperiment): FunnelExperimentDTO =>
+  pickDTOFields(funnelExperiment, funnelExperimentDTOKeys);
+
+
+const funnelAnalyticsDTOKeys = ["id", "blueprint_id", "date"] as const;
+
+export interface FunnelAnalyticsDTO
+  extends Pick<FunnelAnalytics, (typeof funnelAnalyticsDTOKeys)[number]> {}
+
+export const toFunnelAnalyticsDTO = (funnelAnalytics: FunnelAnalytics): FunnelAnalyticsDTO =>
+  pickDTOFields(funnelAnalytics, funnelAnalyticsDTOKeys);
+
+
+const funnelLifecycleIntegrationDTOKeys = ["id", "title", "status"] as const;
+
+export interface FunnelLifecycleIntegrationDTO
+  extends Pick<FunnelLifecycleIntegration, (typeof funnelLifecycleIntegrationDTOKeys)[number]> {}
+
+export const toFunnelLifecycleIntegrationDTO = (funnelLifecycleIntegration: FunnelLifecycleIntegration): FunnelLifecycleIntegrationDTO =>
+  pickDTOFields(funnelLifecycleIntegration, funnelLifecycleIntegrationDTOKeys);
+
+
+const funnelOptimizationDTOKeys = ["id", "status", "category"] as const;
+
+export interface FunnelOptimizationDTO
+  extends Pick<FunnelOptimization, (typeof funnelOptimizationDTOKeys)[number]> {}
+
+export const toFunnelOptimizationDTO = (funnelOptimization: FunnelOptimization): FunnelOptimizationDTO =>
+  pickDTOFields(funnelOptimization, funnelOptimizationDTOKeys);
+

--- a/shared/storefrontTables.ts
+++ b/shared/storefrontTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // Digital Products table - Core product catalog
 export const digitalProducts = pgTable("digital_products", {
   id: serial("id").primaryKey(),
@@ -440,22 +442,122 @@ export const insertAffiliatePartnerSchema = createInsertSchema(affiliatePartners
 });
 
 // Type exports
-export type InsertDigitalProduct = z.infer<typeof insertDigitalProductSchema>;
-export type DigitalProduct = typeof digitalProducts.$inferSelect;
+export type InsertDigitalProduct = InferInsertModel<typeof digitalProducts>;
+export type DigitalProduct = InferSelectModel<typeof digitalProducts>;
 
-export type InsertOrder = z.infer<typeof insertOrderSchema>;
-export type Order = typeof orders.$inferSelect;
+export type InsertOrder = InferInsertModel<typeof orders>;
+export type Order = InferSelectModel<typeof orders>;
 
-export type InsertPromoCode = z.infer<typeof insertPromoCodeSchema>;
-export type PromoCode = typeof promoCodes.$inferSelect;
+export type InsertPromoCode = InferInsertModel<typeof promoCodes>;
+export type PromoCode = InferSelectModel<typeof promoCodes>;
 
-export type InsertAffiliatePartner = z.infer<typeof insertAffiliatePartnerSchema>;
-export type AffiliatePartner = typeof affiliatePartners.$inferSelect;
+export type InsertAffiliatePartner = InferInsertModel<typeof affiliatePartners>;
+export type AffiliatePartner = InferSelectModel<typeof affiliatePartners>;
 
-export type ProductVariant = typeof productVariants.$inferSelect;
-export type ShoppingCart = typeof shoppingCarts.$inferSelect;
-export type ProductLicense = typeof productLicenses.$inferSelect;
-export type ProductReview = typeof productReviews.$inferSelect;
-export type AffiliateTracking = typeof affiliateTracking.$inferSelect;
-export type StorefrontAnalytics = typeof storefrontAnalytics.$inferSelect;
-export type StorefrontABTest = typeof storefrontABTests.$inferSelect;
+export type ProductVariant = InferSelectModel<typeof productVariants>;
+export type ShoppingCart = InferSelectModel<typeof shoppingCarts>;
+export type ProductLicense = InferSelectModel<typeof productLicenses>;
+export type ProductReview = InferSelectModel<typeof productReviews>;
+export type AffiliateTracking = InferSelectModel<typeof affiliateTracking>;
+export type StorefrontAnalytics = InferSelectModel<typeof storefrontAnalytics>;
+export type StorefrontABTest = InferSelectModel<typeof storefrontABTests>;
+
+// DTOs
+const digitalProductDTOKeys = ["id", "title", "slug", "status", "category", "createdAt", "updatedAt", "description"] as const;
+
+export interface DigitalProductDTO
+  extends Pick<DigitalProduct, (typeof digitalProductDTOKeys)[number]> {}
+
+export const toDigitalProductDTO = (digitalProduct: DigitalProduct): DigitalProductDTO =>
+  pickDTOFields(digitalProduct, digitalProductDTOKeys);
+
+
+const orderDTOKeys = ["id", "sessionId", "userId", "createdAt", "updatedAt", "email"] as const;
+
+export interface OrderDTO
+  extends Pick<Order, (typeof orderDTOKeys)[number]> {}
+
+export const toOrderDTO = (order: Order): OrderDTO =>
+  pickDTOFields(order, orderDTOKeys);
+
+
+const promoCodeDTOKeys = ["id", "name", "code", "createdAt", "updatedAt", "description"] as const;
+
+export interface PromoCodeDTO
+  extends Pick<PromoCode, (typeof promoCodeDTOKeys)[number]> {}
+
+export const toPromoCodeDTO = (promoCode: PromoCode): PromoCodeDTO =>
+  pickDTOFields(promoCode, promoCodeDTOKeys);
+
+
+const affiliatePartnerDTOKeys = ["id", "name", "status", "createdAt", "updatedAt", "email", "phone"] as const;
+
+export interface AffiliatePartnerDTO
+  extends Pick<AffiliatePartner, (typeof affiliatePartnerDTOKeys)[number]> {}
+
+export const toAffiliatePartnerDTO = (affiliatePartner: AffiliatePartner): AffiliatePartnerDTO =>
+  pickDTOFields(affiliatePartner, affiliatePartnerDTOKeys);
+
+
+const productVariantDTOKeys = ["id", "name", "createdAt", "productId"] as const;
+
+export interface ProductVariantDTO
+  extends Pick<ProductVariant, (typeof productVariantDTOKeys)[number]> {}
+
+export const toProductVariantDTO = (productVariant: ProductVariant): ProductVariantDTO =>
+  pickDTOFields(productVariant, productVariantDTOKeys);
+
+
+const shoppingCartDTOKeys = ["id", "sessionId", "userId", "createdAt", "updatedAt"] as const;
+
+export interface ShoppingCartDTO
+  extends Pick<ShoppingCart, (typeof shoppingCartDTOKeys)[number]> {}
+
+export const toShoppingCartDTO = (shoppingCart: ShoppingCart): ShoppingCartDTO =>
+  pickDTOFields(shoppingCart, shoppingCartDTOKeys);
+
+
+const productLicenseDTOKeys = ["id", "status", "userId", "createdAt", "updatedAt", "productId"] as const;
+
+export interface ProductLicenseDTO
+  extends Pick<ProductLicense, (typeof productLicenseDTOKeys)[number]> {}
+
+export const toProductLicenseDTO = (productLicense: ProductLicense): ProductLicenseDTO =>
+  pickDTOFields(productLicense, productLicenseDTOKeys);
+
+
+const productReviewDTOKeys = ["id", "title", "status", "userId", "createdAt", "updatedAt", "email", "productId"] as const;
+
+export interface ProductReviewDTO
+  extends Pick<ProductReview, (typeof productReviewDTOKeys)[number]> {}
+
+export const toProductReviewDTO = (productReview: ProductReview): ProductReviewDTO =>
+  pickDTOFields(productReview, productReviewDTOKeys);
+
+
+const affiliateTrackingDTOKeys = ["id", "sessionId", "userId", "createdAt", "updatedAt", "productId", "source"] as const;
+
+export interface AffiliateTrackingDTO
+  extends Pick<AffiliateTracking, (typeof affiliateTrackingDTOKeys)[number]> {}
+
+export const toAffiliateTrackingDTO = (affiliateTracking: AffiliateTracking): AffiliateTrackingDTO =>
+  pickDTOFields(affiliateTracking, affiliateTrackingDTOKeys);
+
+
+const storefrontAnalyticsDTOKeys = ["id", "sessionId", "userId", "createdAt", "eventType", "productId"] as const;
+
+export interface StorefrontAnalyticsDTO
+  extends Pick<StorefrontAnalytics, (typeof storefrontAnalyticsDTOKeys)[number]> {}
+
+export const toStorefrontAnalyticsDTO = (storefrontAnalytics: StorefrontAnalytics): StorefrontAnalyticsDTO =>
+  pickDTOFields(storefrontAnalytics, storefrontAnalyticsDTOKeys);
+
+
+const storefrontABTestDTOKeys = ["id", "name", "status", "createdAt", "updatedAt", "description"] as const;
+
+export interface StorefrontABTestDTO
+  extends Pick<StorefrontABTest, (typeof storefrontABTestDTOKeys)[number]> {}
+
+export const toStorefrontABTestDTO = (storefrontABTest: StorefrontABTest): StorefrontABTestDTO =>
+  pickDTOFields(storefrontABTest, storefrontABTestDTOKeys);
+

--- a/shared/trafficGeneratorTables.ts
+++ b/shared/trafficGeneratorTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // ===== PROGRAMMATIC BLOG SWARM TABLES =====
 
 export const blogSwarmPosts = pgTable("blog_swarm_posts", {
@@ -499,3 +501,214 @@ export const insertDataVisualizationSchema = createInsertSchema(dataVisualizatio
 export const insertPublicApiSchema = createInsertSchema(publicApis);
 export const insertApiKeySchema = createInsertSchema(apiKeys);
 export const insertPublicWidgetSchema = createInsertSchema(publicWidgets);
+
+export type TrafficGeneratorBlogSwarmPost = InferSelectModel<typeof blogSwarmPosts>;
+export type InsertTrafficGeneratorBlogSwarmPost = InferInsertModel<typeof blogSwarmPosts>;
+export type TrafficGeneratorBlogSwarmTemplate = InferSelectModel<typeof blogSwarmTemplates>;
+export type InsertTrafficGeneratorBlogSwarmTemplate = InferInsertModel<typeof blogSwarmTemplates>;
+export type TrafficGeneratorBlogSwarmKeyword = InferSelectModel<typeof blogSwarmKeywords>;
+export type InsertTrafficGeneratorBlogSwarmKeyword = InferInsertModel<typeof blogSwarmKeywords>;
+export type TrafficGeneratorBlogSwarmAnalytic = InferSelectModel<typeof blogSwarmAnalytics>;
+export type InsertTrafficGeneratorBlogSwarmAnalytic = InferInsertModel<typeof blogSwarmAnalytics>;
+export type TrafficGeneratorNewsletterCampaign = InferSelectModel<typeof newsletterCampaigns>;
+export type InsertTrafficGeneratorNewsletterCampaign = InferInsertModel<typeof newsletterCampaigns>;
+export type TrafficGeneratorNewsletterSubscriber = InferSelectModel<typeof newsletterSubscribers>;
+export type InsertTrafficGeneratorNewsletterSubscriber = InferInsertModel<typeof newsletterSubscribers>;
+export type TrafficGeneratorNewsletterAnalytic = InferSelectModel<typeof newsletterAnalytics>;
+export type InsertTrafficGeneratorNewsletterAnalytic = InferInsertModel<typeof newsletterAnalytics>;
+export type TrafficGeneratorForumCategory = InferSelectModel<typeof forumCategories>;
+export type InsertTrafficGeneratorForumCategory = InferInsertModel<typeof forumCategories>;
+export type TrafficGeneratorForumPost = InferSelectModel<typeof forumPosts>;
+export type InsertTrafficGeneratorForumPost = InferInsertModel<typeof forumPosts>;
+export type TrafficGeneratorForumAnswer = InferSelectModel<typeof forumAnswers>;
+export type InsertTrafficGeneratorForumAnswer = InferInsertModel<typeof forumAnswers>;
+export type TrafficGeneratorResourceCategory = InferSelectModel<typeof resourceCategories>;
+export type InsertTrafficGeneratorResourceCategory = InferInsertModel<typeof resourceCategories>;
+export type TrafficGeneratorResourceDirectory = InferSelectModel<typeof resourceDirectory>;
+export type InsertTrafficGeneratorResourceDirectory = InferInsertModel<typeof resourceDirectory>;
+export type TrafficGeneratorResourceReview = InferSelectModel<typeof resourceReviews>;
+export type InsertTrafficGeneratorResourceReview = InferInsertModel<typeof resourceReviews>;
+export type TrafficGeneratorDataVisualization = InferSelectModel<typeof dataVisualizations>;
+export type InsertTrafficGeneratorDataVisualization = InferInsertModel<typeof dataVisualizations>;
+export type TrafficGeneratorDataVisualizationAnalytic = InferSelectModel<typeof dataVisualizationAnalytics>;
+export type InsertTrafficGeneratorDataVisualizationAnalytic = InferInsertModel<typeof dataVisualizationAnalytics>;
+export type TrafficGeneratorPublicApi = InferSelectModel<typeof publicApis>;
+export type InsertTrafficGeneratorPublicApi = InferInsertModel<typeof publicApis>;
+export type TrafficGeneratorApiKey = InferSelectModel<typeof apiKeys>;
+export type InsertTrafficGeneratorApiKey = InferInsertModel<typeof apiKeys>;
+export type TrafficGeneratorApiUsageAnalytic = InferSelectModel<typeof apiUsageAnalytics>;
+export type InsertTrafficGeneratorApiUsageAnalytic = InferInsertModel<typeof apiUsageAnalytics>;
+export type TrafficGeneratorPublicWidget = InferSelectModel<typeof publicWidgets>;
+export type InsertTrafficGeneratorPublicWidget = InferInsertModel<typeof publicWidgets>;
+
+// DTOs
+const trafficGeneratorBlogSwarmPostDTOKeys = ["id", "title", "slug", "status", "state", "type", "category", "vertical", "createdAt", "updatedAt"] as const;
+
+export interface TrafficGeneratorBlogSwarmPostDTO
+  extends Pick<TrafficGeneratorBlogSwarmPost, (typeof trafficGeneratorBlogSwarmPostDTOKeys)[number]> {}
+
+export const toTrafficGeneratorBlogSwarmPostDTO = (trafficGeneratorBlogSwarmPost: TrafficGeneratorBlogSwarmPost): TrafficGeneratorBlogSwarmPostDTO =>
+  pickDTOFields(trafficGeneratorBlogSwarmPost, trafficGeneratorBlogSwarmPostDTOKeys);
+
+
+const trafficGeneratorBlogSwarmTemplateDTOKeys = ["id", "name", "vertical", "createdAt", "updatedAt"] as const;
+
+export interface TrafficGeneratorBlogSwarmTemplateDTO
+  extends Pick<TrafficGeneratorBlogSwarmTemplate, (typeof trafficGeneratorBlogSwarmTemplateDTOKeys)[number]> {}
+
+export const toTrafficGeneratorBlogSwarmTemplateDTO = (trafficGeneratorBlogSwarmTemplate: TrafficGeneratorBlogSwarmTemplate): TrafficGeneratorBlogSwarmTemplateDTO =>
+  pickDTOFields(trafficGeneratorBlogSwarmTemplate, trafficGeneratorBlogSwarmTemplateDTOKeys);
+
+
+const trafficGeneratorBlogSwarmKeywordDTOKeys = ["id", "vertical", "createdAt"] as const;
+
+export interface TrafficGeneratorBlogSwarmKeywordDTO
+  extends Pick<TrafficGeneratorBlogSwarmKeyword, (typeof trafficGeneratorBlogSwarmKeywordDTOKeys)[number]> {}
+
+export const toTrafficGeneratorBlogSwarmKeywordDTO = (trafficGeneratorBlogSwarmKeyword: TrafficGeneratorBlogSwarmKeyword): TrafficGeneratorBlogSwarmKeywordDTO =>
+  pickDTOFields(trafficGeneratorBlogSwarmKeyword, trafficGeneratorBlogSwarmKeywordDTOKeys);
+
+
+const trafficGeneratorBlogSwarmAnalyticDTOKeys = ["id", "createdAt", "postId"] as const;
+
+export interface TrafficGeneratorBlogSwarmAnalyticDTO
+  extends Pick<TrafficGeneratorBlogSwarmAnalytic, (typeof trafficGeneratorBlogSwarmAnalyticDTOKeys)[number]> {}
+
+export const toTrafficGeneratorBlogSwarmAnalyticDTO = (trafficGeneratorBlogSwarmAnalytic: TrafficGeneratorBlogSwarmAnalytic): TrafficGeneratorBlogSwarmAnalyticDTO =>
+  pickDTOFields(trafficGeneratorBlogSwarmAnalytic, trafficGeneratorBlogSwarmAnalyticDTOKeys);
+
+
+const trafficGeneratorNewsletterCampaignDTOKeys = ["id", "name", "status", "type", "vertical", "createdAt", "updatedAt"] as const;
+
+export interface TrafficGeneratorNewsletterCampaignDTO
+  extends Pick<TrafficGeneratorNewsletterCampaign, (typeof trafficGeneratorNewsletterCampaignDTOKeys)[number]> {}
+
+export const toTrafficGeneratorNewsletterCampaignDTO = (trafficGeneratorNewsletterCampaign: TrafficGeneratorNewsletterCampaign): TrafficGeneratorNewsletterCampaignDTO =>
+  pickDTOFields(trafficGeneratorNewsletterCampaign, trafficGeneratorNewsletterCampaignDTOKeys);
+
+
+const trafficGeneratorNewsletterSubscriberDTOKeys = ["id", "status", "vertical", "language", "createdAt", "updatedAt", "email", "source"] as const;
+
+export interface TrafficGeneratorNewsletterSubscriberDTO
+  extends Pick<TrafficGeneratorNewsletterSubscriber, (typeof trafficGeneratorNewsletterSubscriberDTOKeys)[number]> {}
+
+export const toTrafficGeneratorNewsletterSubscriberDTO = (trafficGeneratorNewsletterSubscriber: TrafficGeneratorNewsletterSubscriber): TrafficGeneratorNewsletterSubscriberDTO =>
+  pickDTOFields(trafficGeneratorNewsletterSubscriber, trafficGeneratorNewsletterSubscriberDTOKeys);
+
+
+const trafficGeneratorNewsletterAnalyticDTOKeys = ["id", "state", "campaignId", "country"] as const;
+
+export interface TrafficGeneratorNewsletterAnalyticDTO
+  extends Pick<TrafficGeneratorNewsletterAnalytic, (typeof trafficGeneratorNewsletterAnalyticDTOKeys)[number]> {}
+
+export const toTrafficGeneratorNewsletterAnalyticDTO = (trafficGeneratorNewsletterAnalytic: TrafficGeneratorNewsletterAnalytic): TrafficGeneratorNewsletterAnalyticDTO =>
+  pickDTOFields(trafficGeneratorNewsletterAnalytic, trafficGeneratorNewsletterAnalyticDTOKeys);
+
+
+const trafficGeneratorForumCategoryDTOKeys = ["id", "name", "slug", "vertical", "createdAt", "updatedAt", "description"] as const;
+
+export interface TrafficGeneratorForumCategoryDTO
+  extends Pick<TrafficGeneratorForumCategory, (typeof trafficGeneratorForumCategoryDTOKeys)[number]> {}
+
+export const toTrafficGeneratorForumCategoryDTO = (trafficGeneratorForumCategory: TrafficGeneratorForumCategory): TrafficGeneratorForumCategoryDTO =>
+  pickDTOFields(trafficGeneratorForumCategory, trafficGeneratorForumCategoryDTOKeys);
+
+
+const trafficGeneratorForumPostDTOKeys = ["id", "title", "slug", "status", "type", "createdAt", "updatedAt"] as const;
+
+export interface TrafficGeneratorForumPostDTO
+  extends Pick<TrafficGeneratorForumPost, (typeof trafficGeneratorForumPostDTOKeys)[number]> {}
+
+export const toTrafficGeneratorForumPostDTO = (trafficGeneratorForumPost: TrafficGeneratorForumPost): TrafficGeneratorForumPostDTO =>
+  pickDTOFields(trafficGeneratorForumPost, trafficGeneratorForumPostDTOKeys);
+
+
+const trafficGeneratorForumAnswerDTOKeys = ["id", "createdAt", "updatedAt"] as const;
+
+export interface TrafficGeneratorForumAnswerDTO
+  extends Pick<TrafficGeneratorForumAnswer, (typeof trafficGeneratorForumAnswerDTOKeys)[number]> {}
+
+export const toTrafficGeneratorForumAnswerDTO = (trafficGeneratorForumAnswer: TrafficGeneratorForumAnswer): TrafficGeneratorForumAnswerDTO =>
+  pickDTOFields(trafficGeneratorForumAnswer, trafficGeneratorForumAnswerDTOKeys);
+
+
+const trafficGeneratorResourceCategoryDTOKeys = ["id", "name", "slug", "vertical", "createdAt", "updatedAt", "description"] as const;
+
+export interface TrafficGeneratorResourceCategoryDTO
+  extends Pick<TrafficGeneratorResourceCategory, (typeof trafficGeneratorResourceCategoryDTOKeys)[number]> {}
+
+export const toTrafficGeneratorResourceCategoryDTO = (trafficGeneratorResourceCategory: TrafficGeneratorResourceCategory): TrafficGeneratorResourceCategoryDTO =>
+  pickDTOFields(trafficGeneratorResourceCategory, trafficGeneratorResourceCategoryDTOKeys);
+
+
+const trafficGeneratorResourceDirectoryDTOKeys = ["id", "name", "slug", "status", "type", "createdAt", "updatedAt", "description"] as const;
+
+export interface TrafficGeneratorResourceDirectoryDTO
+  extends Pick<TrafficGeneratorResourceDirectory, (typeof trafficGeneratorResourceDirectoryDTOKeys)[number]> {}
+
+export const toTrafficGeneratorResourceDirectoryDTO = (trafficGeneratorResourceDirectory: TrafficGeneratorResourceDirectory): TrafficGeneratorResourceDirectoryDTO =>
+  pickDTOFields(trafficGeneratorResourceDirectory, trafficGeneratorResourceDirectoryDTOKeys);
+
+
+const trafficGeneratorResourceReviewDTOKeys = ["id", "title", "status", "createdAt", "updatedAt"] as const;
+
+export interface TrafficGeneratorResourceReviewDTO
+  extends Pick<TrafficGeneratorResourceReview, (typeof trafficGeneratorResourceReviewDTOKeys)[number]> {}
+
+export const toTrafficGeneratorResourceReviewDTO = (trafficGeneratorResourceReview: TrafficGeneratorResourceReview): TrafficGeneratorResourceReviewDTO =>
+  pickDTOFields(trafficGeneratorResourceReview, trafficGeneratorResourceReviewDTOKeys);
+
+
+const trafficGeneratorDataVisualizationDTOKeys = ["id", "title", "slug", "status", "type", "vertical", "createdAt", "description"] as const;
+
+export interface TrafficGeneratorDataVisualizationDTO
+  extends Pick<TrafficGeneratorDataVisualization, (typeof trafficGeneratorDataVisualizationDTOKeys)[number]> {}
+
+export const toTrafficGeneratorDataVisualizationDTO = (trafficGeneratorDataVisualization: TrafficGeneratorDataVisualization): TrafficGeneratorDataVisualizationDTO =>
+  pickDTOFields(trafficGeneratorDataVisualization, trafficGeneratorDataVisualizationDTOKeys);
+
+
+const trafficGeneratorDataVisualizationAnalyticDTOKeys = ["id", "createdAt", "visualizationId"] as const;
+
+export interface TrafficGeneratorDataVisualizationAnalyticDTO
+  extends Pick<TrafficGeneratorDataVisualizationAnalytic, (typeof trafficGeneratorDataVisualizationAnalyticDTOKeys)[number]> {}
+
+export const toTrafficGeneratorDataVisualizationAnalyticDTO = (trafficGeneratorDataVisualizationAnalytic: TrafficGeneratorDataVisualizationAnalytic): TrafficGeneratorDataVisualizationAnalyticDTO =>
+  pickDTOFields(trafficGeneratorDataVisualizationAnalytic, trafficGeneratorDataVisualizationAnalyticDTOKeys);
+
+
+const trafficGeneratorPublicApiDTOKeys = ["id", "name", "slug", "status", "category", "vertical", "createdAt", "updatedAt"] as const;
+
+export interface TrafficGeneratorPublicApiDTO
+  extends Pick<TrafficGeneratorPublicApi, (typeof trafficGeneratorPublicApiDTOKeys)[number]> {}
+
+export const toTrafficGeneratorPublicApiDTO = (trafficGeneratorPublicApi: TrafficGeneratorPublicApi): TrafficGeneratorPublicApiDTO =>
+  pickDTOFields(trafficGeneratorPublicApi, trafficGeneratorPublicApiDTOKeys);
+
+
+const trafficGeneratorApiKeyDTOKeys = ["id", "name", "createdAt", "email"] as const;
+
+export interface TrafficGeneratorApiKeyDTO
+  extends Pick<TrafficGeneratorApiKey, (typeof trafficGeneratorApiKeyDTOKeys)[number]> {}
+
+export const toTrafficGeneratorApiKeyDTO = (trafficGeneratorApiKey: TrafficGeneratorApiKey): TrafficGeneratorApiKeyDTO =>
+  pickDTOFields(trafficGeneratorApiKey, trafficGeneratorApiKeyDTOKeys);
+
+
+const trafficGeneratorApiUsageAnalyticDTOKeys = ["id", "apiId", "keyId"] as const;
+
+export interface TrafficGeneratorApiUsageAnalyticDTO
+  extends Pick<TrafficGeneratorApiUsageAnalytic, (typeof trafficGeneratorApiUsageAnalyticDTOKeys)[number]> {}
+
+export const toTrafficGeneratorApiUsageAnalyticDTO = (trafficGeneratorApiUsageAnalytic: TrafficGeneratorApiUsageAnalytic): TrafficGeneratorApiUsageAnalyticDTO =>
+  pickDTOFields(trafficGeneratorApiUsageAnalytic, trafficGeneratorApiUsageAnalyticDTOKeys);
+
+
+const trafficGeneratorPublicWidgetDTOKeys = ["id", "name", "slug", "type", "category", "vertical", "createdAt", "updatedAt"] as const;
+
+export interface TrafficGeneratorPublicWidgetDTO
+  extends Pick<TrafficGeneratorPublicWidget, (typeof trafficGeneratorPublicWidgetDTOKeys)[number]> {}
+
+export const toTrafficGeneratorPublicWidgetDTO = (trafficGeneratorPublicWidget: TrafficGeneratorPublicWidget): TrafficGeneratorPublicWidgetDTO =>
+  pickDTOFields(trafficGeneratorPublicWidget, trafficGeneratorPublicWidgetDTOKeys);
+

--- a/shared/travelTables.ts
+++ b/shared/travelTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, dec
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 // Travel Destinations table
 export const travelDestinations = pgTable("travel_destinations", {
   id: serial("id").primaryKey(),
@@ -285,35 +287,135 @@ export const insertTravelAnalyticsEventSchema = createInsertSchema(travelAnalyti
 });
 
 // Type exports
-export type TravelDestination = typeof travelDestinations.$inferSelect;
-export type InsertTravelDestination = z.infer<typeof insertTravelDestinationSchema>;
+export type TravelDestination = InferSelectModel<typeof travelDestinations>;
+export type InsertTravelDestination = InferInsertModel<typeof travelDestinations>;
 
-export type TravelArticle = typeof travelArticles.$inferSelect;
-export type InsertTravelArticle = z.infer<typeof insertTravelArticleSchema>;
+export type TravelArticle = InferSelectModel<typeof travelArticles>;
+export type InsertTravelArticle = InferInsertModel<typeof travelArticles>;
 
-export type TravelArchetype = typeof travelArchetypes.$inferSelect;
-export type InsertTravelArchetype = z.infer<typeof insertTravelArchetypeSchema>;
+export type TravelArchetype = InferSelectModel<typeof travelArchetypes>;
+export type InsertTravelArchetype = InferInsertModel<typeof travelArchetypes>;
 
-export type TravelQuizQuestion = typeof travelQuizQuestions.$inferSelect;
-export type InsertTravelQuizQuestion = z.infer<typeof insertTravelQuizQuestionSchema>;
+export type TravelQuizQuestion = InferSelectModel<typeof travelQuizQuestions>;
+export type InsertTravelQuizQuestion = InferInsertModel<typeof travelQuizQuestions>;
 
-export type TravelQuizResult = typeof travelQuizResults.$inferSelect;
-export type InsertTravelQuizResult = z.infer<typeof insertTravelQuizResultSchema>;
+export type TravelQuizResult = InferSelectModel<typeof travelQuizResults>;
+export type InsertTravelQuizResult = InferInsertModel<typeof travelQuizResults>;
 
-export type TravelOffer = typeof travelOffers.$inferSelect;
-export type InsertTravelOffer = z.infer<typeof insertTravelOfferSchema>;
+export type TravelOffer = InferSelectModel<typeof travelOffers>;
+export type InsertTravelOffer = InferInsertModel<typeof travelOffers>;
 
-export type TravelItinerary = typeof travelItineraries.$inferSelect;
-export type InsertTravelItinerary = z.infer<typeof insertTravelItinerarySchema>;
+export type TravelItinerary = InferSelectModel<typeof travelItineraries>;
+export type InsertTravelItinerary = InferInsertModel<typeof travelItineraries>;
 
-export type TravelTool = typeof travelTools.$inferSelect;
-export type InsertTravelTool = z.infer<typeof insertTravelToolSchema>;
+export type TravelTool = InferSelectModel<typeof travelTools>;
+export type InsertTravelTool = InferInsertModel<typeof travelTools>;
 
-export type TravelUserSession = typeof travelUserSessions.$inferSelect;
-export type InsertTravelUserSession = z.infer<typeof insertTravelUserSessionSchema>;
+export type TravelUserSession = InferSelectModel<typeof travelUserSessions>;
+export type InsertTravelUserSession = InferInsertModel<typeof travelUserSessions>;
 
-export type TravelContentSource = typeof travelContentSources.$inferSelect;
-export type InsertTravelContentSource = z.infer<typeof insertTravelContentSourceSchema>;
+export type TravelContentSource = InferSelectModel<typeof travelContentSources>;
+export type InsertTravelContentSource = InferInsertModel<typeof travelContentSources>;
 
-export type TravelAnalyticsEvent = typeof travelAnalyticsEvents.$inferSelect;
-export type InsertTravelAnalyticsEvent = z.infer<typeof insertTravelAnalyticsEventSchema>;
+export type TravelAnalyticsEvent = InferSelectModel<typeof travelAnalyticsEvents>;
+export type InsertTravelAnalyticsEvent = InferInsertModel<typeof travelAnalyticsEvents>;
+
+// DTOs
+const travelDestinationDTOKeys = ["id", "name", "slug", "country", "language", "createdAt", "updatedAt", "description"] as const;
+
+export interface TravelDestinationDTO
+  extends Pick<TravelDestination, (typeof travelDestinationDTOKeys)[number]> {}
+
+export const toTravelDestinationDTO = (travelDestination: TravelDestination): TravelDestinationDTO =>
+  pickDTOFields(travelDestination, travelDestinationDTOKeys);
+
+
+const travelArticleDTOKeys = ["id", "title", "slug", "createdAt", "updatedAt"] as const;
+
+export interface TravelArticleDTO
+  extends Pick<TravelArticle, (typeof travelArticleDTOKeys)[number]> {}
+
+export const toTravelArticleDTO = (travelArticle: TravelArticle): TravelArticleDTO =>
+  pickDTOFields(travelArticle, travelArticleDTOKeys);
+
+
+const travelArchetypeDTOKeys = ["id", "name", "slug", "createdAt", "updatedAt", "description"] as const;
+
+export interface TravelArchetypeDTO
+  extends Pick<TravelArchetype, (typeof travelArchetypeDTOKeys)[number]> {}
+
+export const toTravelArchetypeDTO = (travelArchetype: TravelArchetype): TravelArchetypeDTO =>
+  pickDTOFields(travelArchetype, travelArchetypeDTOKeys);
+
+
+const travelQuizQuestionDTOKeys = ["id", "createdAt", "quizType"] as const;
+
+export interface TravelQuizQuestionDTO
+  extends Pick<TravelQuizQuestion, (typeof travelQuizQuestionDTOKeys)[number]> {}
+
+export const toTravelQuizQuestionDTO = (travelQuizQuestion: TravelQuizQuestion): TravelQuizQuestionDTO =>
+  pickDTOFields(travelQuizQuestion, travelQuizQuestionDTOKeys);
+
+
+const travelQuizResultDTOKeys = ["id", "sessionId", "userId", "archetypeId", "createdAt", "quizType"] as const;
+
+export interface TravelQuizResultDTO
+  extends Pick<TravelQuizResult, (typeof travelQuizResultDTOKeys)[number]> {}
+
+export const toTravelQuizResultDTO = (travelQuizResult: TravelQuizResult): TravelQuizResultDTO =>
+  pickDTOFields(travelQuizResult, travelQuizResultDTOKeys);
+
+
+const travelOfferDTOKeys = ["id", "title", "destinationId", "priority", "createdAt", "updatedAt", "description", "provider"] as const;
+
+export interface TravelOfferDTO
+  extends Pick<TravelOffer, (typeof travelOfferDTOKeys)[number]> {}
+
+export const toTravelOfferDTO = (travelOffer: TravelOffer): TravelOfferDTO =>
+  pickDTOFields(travelOffer, travelOfferDTOKeys);
+
+
+const travelItineraryDTOKeys = ["id", "title", "slug", "createdAt", "updatedAt", "description", "budget"] as const;
+
+export interface TravelItineraryDTO
+  extends Pick<TravelItinerary, (typeof travelItineraryDTOKeys)[number]> {}
+
+export const toTravelItineraryDTO = (travelItinerary: TravelItinerary): TravelItineraryDTO =>
+  pickDTOFields(travelItinerary, travelItineraryDTOKeys);
+
+
+const travelToolDTOKeys = ["id", "name", "slug", "createdAt", "updatedAt", "description"] as const;
+
+export interface TravelToolDTO
+  extends Pick<TravelTool, (typeof travelToolDTOKeys)[number]> {}
+
+export const toTravelToolDTO = (travelTool: TravelTool): TravelToolDTO =>
+  pickDTOFields(travelTool, travelToolDTOKeys);
+
+
+const travelUserSessionDTOKeys = ["id", "sessionId", "userId", "archetypeId", "createdAt", "updatedAt"] as const;
+
+export interface TravelUserSessionDTO
+  extends Pick<TravelUserSession, (typeof travelUserSessionDTOKeys)[number]> {}
+
+export const toTravelUserSessionDTO = (travelUserSession: TravelUserSession): TravelUserSessionDTO =>
+  pickDTOFields(travelUserSession, travelUserSessionDTOKeys);
+
+
+const travelContentSourceDTOKeys = ["id", "name", "priority", "createdAt", "updatedAt"] as const;
+
+export interface TravelContentSourceDTO
+  extends Pick<TravelContentSource, (typeof travelContentSourceDTOKeys)[number]> {}
+
+export const toTravelContentSourceDTO = (travelContentSource: TravelContentSource): TravelContentSourceDTO =>
+  pickDTOFields(travelContentSource, travelContentSourceDTOKeys);
+
+
+const travelAnalyticsEventDTOKeys = ["id", "sessionId", "userId", "offerId", "destinationId", "archetypeId", "createdAt", "eventType"] as const;
+
+export interface TravelAnalyticsEventDTO
+  extends Pick<TravelAnalyticsEvent, (typeof travelAnalyticsEventDTOKeys)[number]> {}
+
+export const toTravelAnalyticsEventDTO = (travelAnalyticsEvent: TravelAnalyticsEvent): TravelAnalyticsEventDTO =>
+  pickDTOFields(travelAnalyticsEvent, travelAnalyticsEventDTOKeys);
+

--- a/shared/vectorSearchTables.ts
+++ b/shared/vectorSearchTables.ts
@@ -2,6 +2,8 @@ import { pgTable, text, serial, integer, boolean, timestamp, varchar, jsonb, rea
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { pickDTOFields } from "./dtoHelpers";
 /**
  * Vector Search + Embeddings Engine Database Schema
  * Billion-Dollar Empire Grade - Migration-Proof Architecture
@@ -253,21 +255,103 @@ export const insertVectorSearchAnalyticsSchema = createInsertSchema(vectorSearch
 export const insertVectorMigrationLogSchema = createInsertSchema(vectorMigrationLog);
 
 // Type exports
-export type VectorEmbeddingModel = typeof vectorEmbeddingModels.$inferSelect;
-export type InsertVectorEmbeddingModel = typeof vectorEmbeddingModels.$inferInsert;
-export type VectorDatabaseAdapter = typeof vectorDatabaseAdapters.$inferSelect;
-export type InsertVectorDatabaseAdapter = typeof vectorDatabaseAdapters.$inferInsert;
-export type VectorEmbedding = typeof vectorEmbeddings.$inferSelect;
-export type InsertVectorEmbedding = typeof vectorEmbeddings.$inferInsert;
-export type VectorSearchQuery = typeof vectorSearchQueries.$inferSelect;
-export type InsertVectorSearchQuery = typeof vectorSearchQueries.$inferInsert;
-export type VectorSimilarityCache = typeof vectorSimilarityCache.$inferSelect;
-export type InsertVectorSimilarityCache = typeof vectorSimilarityCache.$inferInsert;
-export type VectorRecommendation = typeof vectorRecommendations.$inferSelect;
-export type InsertVectorRecommendation = typeof vectorRecommendations.$inferInsert;
-export type VectorIndexingJob = typeof vectorIndexingJobs.$inferSelect;
-export type InsertVectorIndexingJob = typeof vectorIndexingJobs.$inferInsert;
-export type VectorSearchAnalytics = typeof vectorSearchAnalytics.$inferSelect;
-export type InsertVectorSearchAnalytics = typeof vectorSearchAnalytics.$inferInsert;
-export type VectorMigrationLog = typeof vectorMigrationLog.$inferSelect;
-export type InsertVectorMigrationLog = typeof vectorMigrationLog.$inferInsert;
+export type VectorEmbeddingModel = InferSelectModel<typeof vectorEmbeddingModels>;
+export type InsertVectorEmbeddingModel = InferInsertModel<typeof vectorEmbeddingModels>;
+export type VectorDatabaseAdapter = InferSelectModel<typeof vectorDatabaseAdapters>;
+export type InsertVectorDatabaseAdapter = InferInsertModel<typeof vectorDatabaseAdapters>;
+export type VectorEmbedding = InferSelectModel<typeof vectorEmbeddings>;
+export type InsertVectorEmbedding = InferInsertModel<typeof vectorEmbeddings>;
+export type VectorSearchQuery = InferSelectModel<typeof vectorSearchQueries>;
+export type InsertVectorSearchQuery = InferInsertModel<typeof vectorSearchQueries>;
+export type VectorSimilarityCache = InferSelectModel<typeof vectorSimilarityCache>;
+export type InsertVectorSimilarityCache = InferInsertModel<typeof vectorSimilarityCache>;
+export type VectorRecommendation = InferSelectModel<typeof vectorRecommendations>;
+export type InsertVectorRecommendation = InferInsertModel<typeof vectorRecommendations>;
+export type VectorIndexingJob = InferSelectModel<typeof vectorIndexingJobs>;
+export type InsertVectorIndexingJob = InferInsertModel<typeof vectorIndexingJobs>;
+export type VectorSearchAnalytics = InferSelectModel<typeof vectorSearchAnalytics>;
+export type InsertVectorSearchAnalytics = InferInsertModel<typeof vectorSearchAnalytics>;
+export type VectorMigrationLog = InferSelectModel<typeof vectorMigrationLog>;
+export type InsertVectorMigrationLog = InferInsertModel<typeof vectorMigrationLog>;
+
+// DTOs
+const vectorEmbeddingModelDTOKeys = ["id", "createdAt", "updatedAt", "provider"] as const;
+
+export interface VectorEmbeddingModelDTO
+  extends Pick<VectorEmbeddingModel, (typeof vectorEmbeddingModelDTOKeys)[number]> {}
+
+export const toVectorEmbeddingModelDTO = (vectorEmbeddingModel: VectorEmbeddingModel): VectorEmbeddingModelDTO =>
+  pickDTOFields(vectorEmbeddingModel, vectorEmbeddingModelDTOKeys);
+
+
+const vectorDatabaseAdapterDTOKeys = ["id", "priority", "createdAt", "updatedAt"] as const;
+
+export interface VectorDatabaseAdapterDTO
+  extends Pick<VectorDatabaseAdapter, (typeof vectorDatabaseAdapterDTOKeys)[number]> {}
+
+export const toVectorDatabaseAdapterDTO = (vectorDatabaseAdapter: VectorDatabaseAdapter): VectorDatabaseAdapterDTO =>
+  pickDTOFields(vectorDatabaseAdapter, vectorDatabaseAdapterDTOKeys);
+
+
+const vectorEmbeddingDTOKeys = ["id", "modelId", "neuronId", "language", "createdAt", "updatedAt", "version"] as const;
+
+export interface VectorEmbeddingDTO
+  extends Pick<VectorEmbedding, (typeof vectorEmbeddingDTOKeys)[number]> {}
+
+export const toVectorEmbeddingDTO = (vectorEmbedding: VectorEmbedding): VectorEmbeddingDTO =>
+  pickDTOFields(vectorEmbedding, vectorEmbeddingDTOKeys);
+
+
+const vectorSearchQueryDTOKeys = ["id", "modelId", "sessionId", "neuronId", "userId", "createdAt"] as const;
+
+export interface VectorSearchQueryDTO
+  extends Pick<VectorSearchQuery, (typeof vectorSearchQueryDTOKeys)[number]> {}
+
+export const toVectorSearchQueryDTO = (vectorSearchQuery: VectorSearchQuery): VectorSearchQueryDTO =>
+  pickDTOFields(vectorSearchQuery, vectorSearchQueryDTOKeys);
+
+
+const vectorSimilarityCacheDTOKeys = ["id", "modelId", "createdAt"] as const;
+
+export interface VectorSimilarityCacheDTO
+  extends Pick<VectorSimilarityCache, (typeof vectorSimilarityCacheDTOKeys)[number]> {}
+
+export const toVectorSimilarityCacheDTO = (vectorSimilarityCache: VectorSimilarityCache): VectorSimilarityCacheDTO =>
+  pickDTOFields(vectorSimilarityCache, vectorSimilarityCacheDTOKeys);
+
+
+const vectorRecommendationDTOKeys = ["id", "modelId", "sessionId", "neuronId", "userId", "createdAt", "updatedAt"] as const;
+
+export interface VectorRecommendationDTO
+  extends Pick<VectorRecommendation, (typeof vectorRecommendationDTOKeys)[number]> {}
+
+export const toVectorRecommendationDTO = (vectorRecommendation: VectorRecommendation): VectorRecommendationDTO =>
+  pickDTOFields(vectorRecommendation, vectorRecommendationDTOKeys);
+
+
+const vectorIndexingJobDTOKeys = ["id", "status", "modelId", "priority", "createdAt", "updatedAt"] as const;
+
+export interface VectorIndexingJobDTO
+  extends Pick<VectorIndexingJob, (typeof vectorIndexingJobDTOKeys)[number]> {}
+
+export const toVectorIndexingJobDTO = (vectorIndexingJob: VectorIndexingJob): VectorIndexingJobDTO =>
+  pickDTOFields(vectorIndexingJob, vectorIndexingJobDTOKeys);
+
+
+const vectorSearchAnalyticsDTOKeys = ["id", "modelId", "neuronId", "createdAt", "updatedAt"] as const;
+
+export interface VectorSearchAnalyticsDTO
+  extends Pick<VectorSearchAnalytics, (typeof vectorSearchAnalyticsDTOKeys)[number]> {}
+
+export const toVectorSearchAnalyticsDTO = (vectorSearchAnalytics: VectorSearchAnalytics): VectorSearchAnalyticsDTO =>
+  pickDTOFields(vectorSearchAnalytics, vectorSearchAnalyticsDTOKeys);
+
+
+const vectorMigrationLogDTOKeys = ["id", "status", "createdAt"] as const;
+
+export interface VectorMigrationLogDTO
+  extends Pick<VectorMigrationLog, (typeof vectorMigrationLogDTOKeys)[number]> {}
+
+export const toVectorMigrationLogDTO = (vectorMigrationLog: VectorMigrationLog): VectorMigrationLogDTO =>
+  pickDTOFields(vectorMigrationLog, vectorMigrationLogDTOKeys);
+


### PR DESCRIPTION
## Summary
- add a dto helper and generator script to automate select/insert model exports and DTO creation for shared tables
- update the shared table definitions to export InferSelectModel/InferInsertModel types and expose to*DTO mappers

## Testing
- npm run check *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68c98408b47c833188bac8574461bbaf