### PR TITLE
Refactor AI tools router initialization

### DIFF
--- a/empire-export/server/routes.ts
+++ b/empire-export/server/routes.ts
@@ -96,7 +96,7 @@ import { semanticRoutes } from "./routes/semantic";
 import { notificationRoutes } from "./routes/notifications";
 import { createTravelRoutes } from "./routes/travel";
 import { registerEducationRoutes } from "./routes/education";
-import { createAiToolsRoutes } from "./routes/aiToolsRoutes";
+import aiToolsRouter, { init as initAiToolsRoutes } from "./routes/aiToolsRoutes";
 import federationRouterBridge from "./routes/federation";
 import federationDashboardRouter from "./routes/federation-dashboard";
 import apiNeuronsRouter from "./routes/apiNeurons";
@@ -4348,7 +4348,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
   registerEducationRoutes(app);
 
   // Register AI Tools Neuron Routes
-  app.use('/api/ai-tools', createAiToolsRoutes(storage));
+  initAiToolsRoutes(storage);
+  app.use('/api/ai-tools', aiToolsRouter);
   
   // AI/ML Centralization Routes
   app.use(aiMLRoutes);

--- a/empire-export/server/routes/aiToolsRoutes.ts
+++ b/empire-export/server/routes/aiToolsRoutes.ts
@@ -11,8 +11,15 @@ import {
 } from '@shared/aiToolsTables';
 import type { DatabaseStorage } from '../storage';
 
-export function createAiToolsRoutes(storage: DatabaseStorage) {
-  const router = Router();
+const router = Router();
+let isInitialized = false;
+
+export function init(storage: DatabaseStorage) {
+  if (isInitialized) {
+    return;
+  }
+
+  isInitialized = true;
 
   // Get all AI tool archetypes
   router.get('/archetypes', async (req, res) => {
@@ -424,5 +431,6 @@ export function createAiToolsRoutes(storage: DatabaseStorage) {
     }
   });
 
-  return router;
 }
+
+export default router;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -112,7 +112,7 @@ import { semanticRoutes } from "./routes/semantic";
 import { notificationRoutes } from "./routes/notifications";
 import { createTravelRoutes } from "./routes/travel";
 import { registerEducationRoutes } from "./routes/education";
-import { createAiToolsRoutes } from "./routes/aiToolsRoutes";
+import aiToolsRouter, { init as initAiToolsRoutes } from "./routes/aiToolsRoutes";
 import federationRouterBridge from "./routes/federation";
 import federationDashboardRouter from "./routes/federation-dashboard";
 import apiNeuronsRouter from "./routes/apiNeurons";
@@ -4371,7 +4371,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
   registerEducationRoutes(app);
 
   // Register AI Tools Neuron Routes
-  app.use('/api/ai-tools', createAiToolsRoutes(storage));
+  initAiToolsRoutes(storage);
+  app.use('/api/ai-tools', aiToolsRouter);
   
   // AI/ML Centralization Routes
   app.use(aiMLRoutes);

--- a/server/routes/aiToolsRoutes.ts
+++ b/server/routes/aiToolsRoutes.ts
@@ -11,8 +11,15 @@ import {
 } from '@shared/aiToolsTables';
 import type { DatabaseStorage } from '../storage';
 
-export function createAiToolsRoutes(storage: DatabaseStorage) {
-  const router = Router();
+const router = Router();
+let isInitialized = false;
+
+export function init(storage: DatabaseStorage) {
+  if (isInitialized) {
+    return;
+  }
+
+  isInitialized = true;
 
   // Get all AI tool archetypes
   router.get('/archetypes', async (req, res) => {
@@ -424,5 +431,6 @@ export function createAiToolsRoutes(storage: DatabaseStorage) {
     }
   });
 
-  return router;
 }
+
+export default router;


### PR DESCRIPTION
## Summary
- refactor the AI tools route modules to expose a shared router with an `init` function that attaches handlers once
- update both server entrypoints to call `init` before mounting the shared router so the new export shape is used consistently

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68c990f094a48331ab698ef7fc629fc7