### PR TITLE
Standardize router exports and add server tsconfig

### DIFF
--- a/empire-export/server/routes.ts
+++ b/empire-export/server/routes.ts
@@ -94,9 +94,9 @@ import AffiliateRedirectEngine from "./services/affiliate/affiliateRedirectEngin
 import AffiliateComplianceEngine from "./services/affiliate/affiliateComplianceEngine";
 import { semanticRoutes } from "./routes/semantic";
 import { notificationRoutes } from "./routes/notifications";
-import { createTravelRoutes } from "./routes/travel";
+import travelRoutes from "./routes/travel";
 import { registerEducationRoutes } from "./routes/education";
-import { createAiToolsRoutes } from "./routes/aiToolsRoutes";
+import aiToolsRoutes from "./routes/aiToolsRoutes";
 import federationRouterBridge from "./routes/federation";
 import federationDashboardRouter from "./routes/federation-dashboard";
 import apiNeuronsRouter from "./routes/apiNeurons";
@@ -4341,14 +4341,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
   registerFinanceRoutes(app);
 
   // Register Travel Neuron Routes
-  const travelRouter = createTravelRoutes(storage);
-  app.use('/api/travel', travelRouter);
+  app.use('/api/travel', travelRoutes);
 
   // Register Education Neuron Routes
   registerEducationRoutes(app);
 
   // Register AI Tools Neuron Routes
-  app.use('/api/ai-tools', createAiToolsRoutes(storage));
+  app.use('/api/ai-tools', aiToolsRoutes);
   
   // AI/ML Centralization Routes
   app.use(aiMLRoutes);

--- a/empire-export/server/routes/aiToolsRoutes.ts
+++ b/empire-export/server/routes/aiToolsRoutes.ts
@@ -1,18 +1,17 @@
 import { Router } from 'express';
 import { z } from 'zod';
 import { validateRequest } from '../middleware/validation';
-import { 
-  insertAiToolsArchetypeSchema, 
-  insertAiToolSchema, 
+import {
+  insertAiToolsArchetypeSchema,
+  insertAiToolSchema,
   insertAiToolsOfferSchema,
   insertAiToolsQuizSchema,
   insertAiToolsContentSchema,
   insertAiToolsLeadSchema
 } from '@shared/aiToolsTables';
-import type { DatabaseStorage } from '../storage';
+import { storage } from '../storage';
 
-export function createAiToolsRoutes(storage: DatabaseStorage) {
-  const router = Router();
+const router = Router();
 
   // Get all AI tool archetypes
   router.get('/archetypes', async (req, res) => {
@@ -424,5 +423,5 @@ export function createAiToolsRoutes(storage: DatabaseStorage) {
     }
   });
 
-  return router;
-}
+export { router as aiToolsRoutes };
+export default router;

--- a/empire-export/server/routes/travel.ts
+++ b/empire-export/server/routes/travel.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { z } from "zod";
-import type { DatabaseStorage } from "../storage";
+import { storage } from "../storage";
 import {
   insertTravelDestinationSchema,
   insertTravelArticleSchema,
@@ -15,8 +15,7 @@ import {
   insertTravelAnalyticsEventSchema,
 } from "@shared/schema";
 
-export function createTravelRoutes(storage: DatabaseStorage) {
-  const router = Router();
+const router = Router();
 
   // === DESTINATION ROUTES ===
   
@@ -580,5 +579,5 @@ export function createTravelRoutes(storage: DatabaseStorage) {
     }
   });
 
-  return router;
-}
+export { router as travelRoutes };
+export default router;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -110,9 +110,9 @@ import AffiliateRedirectEngine from "./services/affiliate/affiliateRedirectEngin
 import AffiliateComplianceEngine from "./services/affiliate/affiliateComplianceEngine";
 import { semanticRoutes } from "./routes/semantic";
 import { notificationRoutes } from "./routes/notifications";
-import { createTravelRoutes } from "./routes/travel";
+import travelRoutes from "./routes/travel";
 import { registerEducationRoutes } from "./routes/education";
-import { createAiToolsRoutes } from "./routes/aiToolsRoutes";
+import aiToolsRoutes from "./routes/aiToolsRoutes";
 import federationRouterBridge from "./routes/federation";
 import federationDashboardRouter from "./routes/federation-dashboard";
 import apiNeuronsRouter from "./routes/apiNeurons";
@@ -4364,14 +4364,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
   registerFinanceRoutes(app);
 
   // Register Travel Neuron Routes
-  const travelRouter = createTravelRoutes(storage);
-  app.use('/api/travel', travelRouter);
+  app.use('/api/travel', travelRoutes);
 
   // Register Education Neuron Routes
   registerEducationRoutes(app);
 
   // Register AI Tools Neuron Routes
-  app.use('/api/ai-tools', createAiToolsRoutes(storage));
+  app.use('/api/ai-tools', aiToolsRoutes);
   
   // AI/ML Centralization Routes
   app.use(aiMLRoutes);

--- a/server/routes/aiToolsRoutes.ts
+++ b/server/routes/aiToolsRoutes.ts
@@ -1,18 +1,17 @@
 import { Router } from 'express';
 import { z } from 'zod';
 import { validateRequest } from '../middleware/validation';
-import { 
-  insertAiToolsArchetypeSchema, 
-  insertAiToolSchema, 
+import {
+  insertAiToolsArchetypeSchema,
+  insertAiToolSchema,
   insertAiToolsOfferSchema,
   insertAiToolsQuizSchema,
   insertAiToolsContentSchema,
   insertAiToolsLeadSchema
 } from '@shared/aiToolsTables';
-import type { DatabaseStorage } from '../storage';
+import { storage } from '../storage';
 
-export function createAiToolsRoutes(storage: DatabaseStorage) {
-  const router = Router();
+const router = Router();
 
   // Get all AI tool archetypes
   router.get('/archetypes', async (req, res) => {
@@ -424,5 +423,5 @@ export function createAiToolsRoutes(storage: DatabaseStorage) {
     }
   });
 
-  return router;
-}
+export { router as aiToolsRoutes };
+export default router;

--- a/server/routes/api/admin.ts
+++ b/server/routes/api/admin.ts
@@ -615,3 +615,4 @@ router.post('/cultural-ab-tests', requireAuth, async (req, res) => {
 });
 
 export { router as adminRouter };
+export default router;

--- a/server/routes/db-health.ts
+++ b/server/routes/db-health.ts
@@ -435,3 +435,4 @@ router.get('/backup', async (req, res) => {
 });
 
 export { router as dbHealthRouter };
+export default router;

--- a/server/routes/enterprise.ts
+++ b/server/routes/enterprise.ts
@@ -209,3 +209,4 @@ router.post('/upgrade', async (req, res) => {
 });
 
 export { router as enterpriseRoutes };
+export default router;

--- a/server/routes/notifications.ts
+++ b/server/routes/notifications.ts
@@ -337,3 +337,4 @@ router.post('/offers/force-sync', async (req, res) => {
 });
 
 export { router as notificationRoutes };
+export default router;

--- a/server/routes/security-audit.ts
+++ b/server/routes/security-audit.ts
@@ -400,3 +400,4 @@ router.post('/incident/report', async (req, res) => {
 });
 
 export { router as securityAuditRouter };
+export default router;

--- a/server/routes/semantic.ts
+++ b/server/routes/semantic.ts
@@ -1548,3 +1548,4 @@ router.post("/ultra/test-independence", async (req: Request, res: Response) => {
 });
 
 export { router as semanticRoutes };
+export default router;

--- a/server/routes/semanticAutoFix.ts
+++ b/server/routes/semanticAutoFix.ts
@@ -100,3 +100,4 @@ router.get('/status', async (req: Request, res: Response) => {
 });
 
 export { router as semanticAutoFixRoutes };
+export default router;

--- a/server/routes/travel.ts
+++ b/server/routes/travel.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { z } from "zod";
-import type { DatabaseStorage } from "../storage";
+import { storage } from "../storage";
 import {
   insertTravelDestinationSchema,
   insertTravelArticleSchema,
@@ -15,8 +15,7 @@ import {
   insertTravelAnalyticsEventSchema,
 } from "@shared/schema";
 
-export function createTravelRoutes(storage: DatabaseStorage) {
-  const router = Router();
+const router = Router();
 
   // === DESTINATION ROUTES ===
   
@@ -580,5 +579,5 @@ export function createTravelRoutes(storage: DatabaseStorage) {
     }
   });
 
-  return router;
-}
+export { router as travelRoutes };
+export default router;

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["server/**/*", "shared/**/*"],
+  "exclude": ["node_modules", "build", "dist", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary
- Instantiate the AI tools and travel routers at module scope using the shared storage instance and export them by default.
- Default-export other router modules (admin, security audit, DB health, semantic auto-fix, notifications, semantic, enterprise) and update both route aggregators to consume the new defaults, mirroring the changes in the empire-export copy.
- Add a dedicated `tsconfig.server.json` to support server-only TypeScript compilation.

## Testing
- `npx tsc -p tsconfig.server.json --noEmit` *(fails: existing type errors in shared/schema.ts and other files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9909e64648331ae7fe922ecf81961