### PR TITLE
feat(client): add typed API helpers and hooks

### DIFF
--- a/client/src/hooks/useDecisions.ts
+++ b/client/src/hooks/useDecisions.ts
@@ -1,0 +1,25 @@
+import { useQuery, type UseQueryOptions, type UseQueryResult } from "@tanstack/react-query";
+import { fetchDecisions, type AutonomicDecision, type DecisionsQueryParams } from "@/lib/api";
+
+const decisionsQueryKey = (params?: DecisionsQueryParams) =>
+  ["/api/empire-brain/decisions", params ?? {}] as const;
+
+type DecisionsQueryKey = ReturnType<typeof decisionsQueryKey>;
+
+type UseDecisionsOptions<TData> = Omit<
+  UseQueryOptions<AutonomicDecision[], Error, TData, DecisionsQueryKey>,
+  "queryKey" | "queryFn"
+>;
+
+export function useDecisions<TData = AutonomicDecision[]>(
+  params?: DecisionsQueryParams,
+  options?: UseDecisionsOptions<TData>,
+): UseQueryResult<TData, Error> {
+  return useQuery({
+    queryKey: decisionsQueryKey(params),
+    queryFn: () => fetchDecisions(params),
+    ...options,
+  });
+}
+
+export { decisionsQueryKey };

--- a/client/src/hooks/useOffers.ts
+++ b/client/src/hooks/useOffers.ts
@@ -1,0 +1,25 @@
+import { useQuery, type UseQueryOptions, type UseQueryResult } from "@tanstack/react-query";
+import { fetchOffers, type OfferFeed, type OffersQueryParams } from "@/lib/api";
+
+const offersQueryKey = (params?: OffersQueryParams) =>
+  ["/api/offer-engine/offers", params ?? {}] as const;
+
+type OffersQueryKey = ReturnType<typeof offersQueryKey>;
+
+type UseOffersOptions<TData> = Omit<
+  UseQueryOptions<OfferFeed[], Error, TData, OffersQueryKey>,
+  "queryKey" | "queryFn"
+>;
+
+export function useOffers<TData = OfferFeed[]>(
+  params?: OffersQueryParams,
+  options?: UseOffersOptions<TData>,
+): UseQueryResult<TData, Error> {
+  return useQuery({
+    queryKey: offersQueryKey(params),
+    queryFn: () => fetchOffers(params),
+    ...options,
+  });
+}
+
+export { offersQueryKey };

--- a/client/src/hooks/useQuiz.ts
+++ b/client/src/hooks/useQuiz.ts
@@ -1,0 +1,34 @@
+import { useQuery, type UseQueryOptions, type UseQueryResult } from "@tanstack/react-query";
+import { fetchQuizBySlug, type EducationQuiz } from "@/lib/api";
+
+const quizQueryKey = (slug: string | null | undefined) =>
+  ["/api/education/quizzes", slug ?? null] as const;
+
+type QuizQueryKey = ReturnType<typeof quizQueryKey>;
+
+type UseQuizOptions<TData> = Omit<
+  UseQueryOptions<EducationQuiz, Error, TData, QuizQueryKey>,
+  "queryKey" | "queryFn"
+>;
+
+export function useQuiz<TData = EducationQuiz>(
+  slug: string | null | undefined,
+  options?: UseQuizOptions<TData>,
+): UseQueryResult<TData, Error> {
+  const { enabled, ...rest } = options ?? {};
+
+  return useQuery({
+    queryKey: quizQueryKey(slug),
+    queryFn: () => {
+      if (!slug) {
+        return Promise.reject(new Error("Quiz slug is required to fetch quiz data."));
+      }
+
+      return fetchQuizBySlug(slug);
+    },
+    enabled: Boolean(slug) && (enabled ?? true),
+    ...rest,
+  });
+}
+
+export { quizQueryKey };

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,0 +1,187 @@
+import { OfferFeed } from "@shared/offerEngineTables";
+import { EducationQuiz } from "@shared/educationTables";
+import { autonomicDecisions } from "@shared/empireBrainTables";
+
+export type AutonomicDecision = typeof autonomicDecisions.$inferSelect;
+export type { OfferFeed, EducationQuiz };
+
+type Primitive = string | number | boolean | Date;
+type QueryValue = Primitive | Primitive[] | undefined | null;
+
+type ApiSuccess<T> = {
+  success: true;
+  data: T;
+  message?: string;
+};
+
+type ApiError = {
+  success: false;
+  error?: string;
+  message?: string;
+};
+
+type ApiResponse<T> = ApiSuccess<T> | ApiError;
+
+function serializeQueryValue(value: Primitive): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return String(value);
+}
+
+function buildQueryString(params?: Record<string, QueryValue>): string {
+  if (!params) {
+    return "";
+  }
+
+  const searchParams = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      if (value.length === 0) {
+        continue;
+      }
+
+      const joined = value.map(serializeQueryValue).join(",");
+      searchParams.set(key, joined);
+      continue;
+    }
+
+    searchParams.set(key, serializeQueryValue(value));
+  }
+
+  const queryString = searchParams.toString();
+  return queryString ? `?${queryString}` : "";
+}
+
+async function fetchJson<T>(input: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(input, {
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+    ...init,
+  });
+
+  if (!response.ok) {
+    const errorMessage = (await response.text()) || response.statusText;
+    throw new Error(errorMessage);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return (await response.json()) as T;
+}
+
+function ensureSuccess<T>(response: ApiResponse<T>, fallbackMessage: string): T {
+  if (!response.success) {
+    throw new Error(response.error ?? response.message ?? fallbackMessage);
+  }
+
+  return response.data;
+}
+
+export interface OffersQueryParams {
+  merchant?: string;
+  category?: string;
+  emotion?: string;
+  region?: string;
+  priceMin?: number;
+  priceMax?: number;
+  isActive?: boolean;
+  isExpired?: boolean;
+  tags?: string[];
+  limit?: number;
+  offset?: number;
+  sortBy?: "relevance" | "price" | "ctr" | "conversion" | "revenue" | "updated";
+  sortOrder?: "asc" | "desc";
+}
+
+export async function fetchOffers(params?: OffersQueryParams): Promise<OfferFeed[]> {
+  const query = buildQueryString({
+    merchant: params?.merchant,
+    category: params?.category,
+    emotion: params?.emotion,
+    region: params?.region,
+    priceMin: params?.priceMin,
+    priceMax: params?.priceMax,
+    isActive: params?.isActive,
+    isExpired: params?.isExpired,
+    tags: params?.tags,
+    limit: params?.limit,
+    offset: params?.offset,
+    sortBy: params?.sortBy,
+    sortOrder: params?.sortOrder,
+  });
+
+  return fetchJson<OfferFeed[]>(`/api/offer-engine/offers${query}`);
+}
+
+export async function fetchOfferBySlug(slug: string): Promise<OfferFeed> {
+  return fetchJson<OfferFeed>(`/api/offer-engine/offers/${encodeURIComponent(slug)}`);
+}
+
+export interface QuizQueryParams {
+  category?: string;
+  type?: string;
+  difficulty?: string;
+}
+
+export async function fetchQuizzes(params?: QuizQueryParams): Promise<EducationQuiz[]> {
+  const query = buildQueryString({
+    category: params?.category,
+    type: params?.type,
+    difficulty: params?.difficulty,
+  });
+
+  const response = await fetchJson<ApiResponse<EducationQuiz[]>>(`/api/education/quizzes${query}`);
+  return ensureSuccess(response, "Failed to fetch quizzes");
+}
+
+export async function fetchQuizBySlug(slug: string): Promise<EducationQuiz> {
+  const response = await fetchJson<ApiResponse<EducationQuiz>>(
+    `/api/education/quizzes/${encodeURIComponent(slug)}`,
+  );
+
+  return ensureSuccess(response, "Failed to fetch quiz");
+}
+
+export interface DecisionsQueryParams {
+  decisionType?: string;
+  status?: string;
+  limit?: number;
+  startDate?: string | Date;
+  endDate?: string | Date;
+}
+
+export async function fetchDecisions(params?: DecisionsQueryParams): Promise<AutonomicDecision[]> {
+  const query = buildQueryString({
+    decisionType: params?.decisionType,
+    status: params?.status,
+    limit: params?.limit,
+    startDate: params?.startDate,
+    endDate: params?.endDate,
+  });
+
+  const response = await fetchJson<ApiResponse<AutonomicDecision[]>>(
+    `/api/empire-brain/decisions${query}`,
+  );
+
+  return ensureSuccess(response, "Failed to fetch decisions");
+}
+
+export async function fetchDecision(decisionId: string): Promise<AutonomicDecision> {
+  const response = await fetchJson<ApiResponse<AutonomicDecision>>(
+    `/api/empire-brain/decisions/${encodeURIComponent(decisionId)}`,
+  );
+
+  return ensureSuccess(response, "Failed to fetch decision");
+}


### PR DESCRIPTION
## Summary
- add typed API helper functions for offers, quizzes, and decisions that leverage shared DTO typings
- introduce dedicated React Query hooks for offers, quiz details, and empire-brain decisions built on the new API helpers

## Testing
- NODE_OPTIONS=--max-old-space-size=8192 npm run check *(fails: pre-existing TypeScript errors in shared/schema.ts and other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c9910b01fc833189ddf83ec0211cdf